### PR TITLE
Upload report as an artifact

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -81,3 +81,10 @@ runs:
         GRADLE_SETTINGS_PATH: "${{ inputs.gradle-settings-path }}"
         ADDITIONAL_VOLUMES: "${{ inputs.additional-volumes }}"
         ADDITIONAL_ENV_VARIABLES: "${{ inputs.additional-env-variables }}"
+    - name: Upload Report
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: Qodana Report
+        path: "${{ inputs.results-dir }}/results/*"
+        if-no-files-found: ignore
+


### PR DESCRIPTION
I think it would be convenient if an artifact was uploaded so I don't have to upload it myself

Or is there some other better way of doing this that I'm unaware of?