### PR TITLE
:bug: Fix annotation path incorrectness when --project-dir is specified

### DIFF
--- a/scan/__tests__/main.test.ts
+++ b/scan/__tests__/main.test.ts
@@ -94,7 +94,8 @@ test('qodana scan command args', () => {
 
 test('test sarif with problems to output annotations', () => {
   const output = annotationsDefaultFixture()
-  const result = parseSarif('__tests__/data/some.sarif.json')
+  const defaultProjectDir = ''
+  const result = parseSarif('__tests__/data/some.sarif.json', defaultProjectDir)
   expect(result.annotations).toEqual(output)
 })
 
@@ -106,7 +107,11 @@ test('test sarif with problems and baseline to output annotations', () => {
 
 test('test sarif with no problems to output annotations', () => {
   const output = outputEmptyFixture()
-  const result = parseSarif('__tests__/data/empty.sarif.json')
+  const defaultProjectDir = ''
+  const result = parseSarif(
+    '__tests__/data/empty.sarif.json',
+    defaultProjectDir
+  )
   expect(result.annotations).toEqual(output)
 })
 

--- a/scan/src/output.ts
+++ b/scan/src/output.ts
@@ -90,7 +90,10 @@ export async function publishOutput(
     return
   }
   try {
-    const problems = parseSarif(`${resultsDir}/${QODANA_SARIF_NAME}`)
+    const problems = parseSarif(
+      `${resultsDir}/${QODANA_SARIF_NAME}`,
+      projectDir
+    )
     const reportUrl = getReportURL(resultsDir)
     const coverageInfo = getCoverageStats(
       getCoverageFromSarif(`${resultsDir}/${QODANA_SHORT_SARIF_NAME}`),


### PR DESCRIPTION
# Pull Request Details
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When `--project-dir` is specified, the output annotation path should start with the project dir path.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://youtrack.jetbrains.com/issue/QD-5189/


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

When we specifies the `--project-dir` argument, the output annotation's path is incorrect, then the annotation is not working expectedly.


For example when we have a mono repo project, which is not a Gradle multi project but just has multiple directories where some are Gradle project and others are not.

```
root_dir/dirA -- non Gradle project
root_dir/dirB -- Gradle project
```

In this situation, we want to use not `--source-directory` but `--project-dir`.

When `--project-dir` is specified, the paths written in the output sarif file is incorrect.

```
actual path - ./path/to/file
expected path - ./dirA/path/to/file
```

If the path is incorrect, qodana-action never comments at the pull request change location.


## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested in my private project. (Sorry it is not public)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/qodana-action/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit messages are styled with [gitmoji](https://gitmoji.dev)
- [ ] My change requires a change to the [documentation](https://jetbrains.com/help/qodana).
  - [ ] [Qodana for GitHub](https://www.jetbrains.com/help/qodana/github.html)
  - [ ] [Qodana for Azure Pipelines](https://www.jetbrains.com/help/qodana/azure-pipelines.html)
  - [ ] [Qodana for CircleCI](https://www.jetbrains.com/help/qodana/circleci.html)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.