### PR TITLE
QD-9962 accept push-fixes for prMode

### DIFF
--- a/scan/src/main.ts
+++ b/scan/src/main.ts
@@ -15,13 +15,11 @@
  */
 
 import * as core from '@actions/core'
-import * as github from '@actions/github'
 import * as io from '@actions/io'
 import {
   FAIL_THRESHOLD_OUTPUT,
   QodanaExitCode,
   isExecutionSuccessful,
-  NONE,
   extractArg
 } from '../../common/qodana'
 import {
@@ -62,16 +60,6 @@ function setFailed(message: string): void {
 async function main(): Promise<void> {
   try {
     const inputs = getInputs()
-    if (
-      inputs.pushFixes !== NONE &&
-      inputs.prMode &&
-      github.context.payload.pull_request !== undefined
-    ) {
-      inputs.pushFixes = NONE
-      core.warning(
-        `push-fixes is currently not supported with pr-mode: true in pull requests. Running Qodana with push-fixes: ${inputs.pushFixes}.`
-      )
-    }
     await io.mkdirP(inputs.resultsDir)
     await io.mkdirP(inputs.cacheDir)
 

--- a/scan/src/utils.ts
+++ b/scan/src/utils.ts
@@ -191,6 +191,13 @@ export async function pushQuickFixes(
       return
     }
     if (mode === BRANCH) {
+      if (pr?.head?.ref) {
+        const commitToCherryPick = (
+          await exec.getExecOutput('git', ['rev-parse', 'HEAD'])
+        ).stdout.trim()
+        await git(['checkout', currentBranch])
+        await git(['cherry-pick', commitToCherryPick])
+      }
       await git(['push', 'origin', currentBranch])
     } else if (mode === PULL_REQUEST) {
       const newBranch = `qodana/quick-fixes-${currentCommit.slice(0, 7)}`

--- a/vsts/vss-extension.dev.json
+++ b/vsts/vss-extension.dev.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "qodana-dev",
   "name": "Qodana (Dev)",
-  "version": "2024.3.132",
+  "version": "2024.3.134",
   "publisher": "JetBrains",
   "targets": [
     {


### PR DESCRIPTION
In the case of the scoped script, Qodana does not have any issues applying fixes in pr-mode. The case of local-changes script will be handled on the linter side.

This pull request includes several changes aimed at improving the functionality and organization of the `scan` module, as well as updating the version of a related extension. The most important changes include removing unused imports, modifying the `pushQuickFixes` function to handle cherry-picking commits, and updating the version in the `vss-extension.dev.json` file.

Code cleanup and organization:

* [`scan/src/main.ts`](diffhunk://#diff-530b1afbf8fe8dbb323a8bfbab2649f500271b3e05da3b2ea83f3e4dc4f13be2L18-L24): Removed unused import of `github` and the constant `NONE`.

Functionality improvements:

* [`scan/src/main.ts`](diffhunk://#diff-530b1afbf8fe8dbb323a8bfbab2649f500271b3e05da3b2ea83f3e4dc4f13be2L65-L74): Removed the check for `pushFixes` in `prMode` to simplify the `main` function.
* [`scan/src/utils.ts`](diffhunk://#diff-ba74b2a722689807e522d2614500b1f75a6960a3363b49cbecd54f5dab7ab220R194-R200): Modified the `pushQuickFixes` function to handle cherry-picking commits when in `BRANCH` mode.
