### PR TITLE
:bug: Filter absent problems and add a test on ignoring absent and unchanged problems

### DIFF
--- a/scan/__tests__/data/with.baseline.sarif.json
+++ b/scan/__tests__/data/with.baseline.sarif.json
@@ -1,0 +1,8387 @@
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "QDJVM",
+          "fullName": "Qodana for JVM",
+          "version": "213.6433.60",
+          "rules": [],
+          "taxa": [],
+          "language": "en-US",
+          "contents": [
+            "localizedData",
+            "nonLocalizedData"
+          ],
+          "isComprehensive": false
+        },
+        "extensions": [
+          {
+            "name": "org.jetbrains.kotlin",
+            "version": "213-1.5.10-release-949-IJ6433",
+            "rules": [
+              {
+                "id": "RedundantRunCatching",
+                "shortDescription": {
+                  "text": "Redundant 'runCatching' call"
+                },
+                "fullDescription": {
+                  "text": "Reports 'runCatching' calls that are immediately followed by 'getOrThrow'. Such calls can be replaced with just 'run'. Example: 'fun foo() = runCatching { doSomething() }.getOrThrow()' After the quick-fix is applied: 'fun foo() = run { doSomething() }'",
+                  "markdown": "Reports `runCatching` calls that are immediately followed by `getOrThrow`. Such calls can be replaced with just `run`.\n\n**Example:**\n\n\n      fun foo() = runCatching { doSomething() }.getOrThrow()\n\nAfter the quick-fix is applied:\n\n\n      fun foo() = run { doSomething() }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SimpleRedundantLet",
+                "shortDescription": {
+                  "text": "Redundant receiver-based 'let' call"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant receiver-based 'let' calls. The quick-fix removes the redundant 'let' call. Example: 'fun test(s: String?): Int? = s?.let { it.length }' After the quick-fix is applied: 'fun test(s: String?): Int? = s?.length'",
+                  "markdown": "Reports redundant receiver-based `let` calls.\n\nThe quick-fix removes the redundant `let` call.\n\n**Example:**\n\n\n      fun test(s: String?): Int? = s?.let { it.length }\n\nAfter the quick-fix is applied:\n\n\n      fun test(s: String?): Int? = s?.length\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveSingleExpressionStringTemplate",
+                "shortDescription": {
+                  "text": "Redundant string template"
+                },
+                "fullDescription": {
+                  "text": "Reports single-expression string templates that can be safely removed. Example: 'val x = \"Hello\"\n  val y = \"$x\"' After the quick-fix is applied: 'val x = \"Hello\"\n  val y = x // <== Updated'",
+                  "markdown": "Reports single-expression string templates that can be safely removed.\n\n**Example:**\n\n      val x = \"Hello\"\n      val y = \"$x\"\n\nAfter the quick-fix is applied:\n\n      val x = \"Hello\"\n      val y = x // <== Updated\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "IncompleteDestructuring",
+                "shortDescription": {
+                  "text": "Incomplete destructuring declaration"
+                },
+                "fullDescription": {
+                  "text": "Reports incomplete destructuring declaration. Example: 'data class Person(val name: String, val age: Int)\n  val person = Person(\"\", 0)\n  val (name) = person' The quick fix completes destructuring declaration with new variables: 'data class Person(val name: String, val age: Int)\n  val person = Person(\"\", 0)\n  val (name, age) = person'",
+                  "markdown": "Reports incomplete destructuring declaration.\n\n**Example:**\n\n\n      data class Person(val name: String, val age: Int)\n      val person = Person(\"\", 0)\n      val (name) = person\n\nThe quick fix completes destructuring declaration with new variables:\n\n\n      data class Person(val name: String, val age: Int)\n      val person = Person(\"\", 0)\n      val (name, age) = person\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ScopeFunctionConversion",
+                "shortDescription": {
+                  "text": "Scope function can be converted to another one"
+                },
+                "fullDescription": {
+                  "text": "Reports scope functions ('let', 'run', 'apply', 'also') that can be converted between each other. Using corresponding functions makes your code simpler. The quick-fix replaces the scope function to another one. Example: 'val x = \"\".let {\n      it.length\n  }' After the quick-fix is applied: 'val x = \"\".run {\n      length\n  }'",
+                  "markdown": "Reports scope functions (`let`, `run`, `apply`, `also`) that can be converted between each other.\n\nUsing corresponding functions makes your code simpler.\n\nThe quick-fix replaces the scope function to another one.\n\n**Example:**\n\n\n      val x = \"\".let {\n          it.length\n      }\n\nAfter the quick-fix is applied:\n\n\n      val x = \"\".run {\n          length\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "TrailingComma",
+                "shortDescription": {
+                  "text": "Trailing comma recommendations"
+                },
+                "fullDescription": {
+                  "text": "Reports trailing commas that are not follow the recommended style guide.",
+                  "markdown": "Reports trailing commas that are not follow the recommended [style guide](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas)."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "FoldInitializerAndIfToElvis",
+                "shortDescription": {
+                  "text": "If-Null return/break/... foldable to '?:'"
+                },
+                "fullDescription": {
+                  "text": "Reports an 'if' expression that checks variable being null or not right after initializing it that can be converted into an elvis operator in the initializer. Example: 'fun test(foo: Int?, bar: Int): Int {\n      var i = foo\n      if (i == null) {\n          return bar\n      }\n      return i\n  }' The quick-fix converts the 'if' expression with an initializer into an elvis expression: 'fun test(foo: Int?, bar: Int): Int {\n      var i = foo ?: return bar\n      return i\n  }'",
+                  "markdown": "Reports an `if` expression that checks variable being null or not right after initializing it that can be converted into an elvis operator in the initializer.\n\n**Example:**\n\n\n      fun test(foo: Int?, bar: Int): Int {\n          var i = foo\n          if (i == null) {\n              return bar\n          }\n          return i\n      }\n\nThe quick-fix converts the `if` expression with an initializer into an elvis expression:\n\n\n      fun test(foo: Int?, bar: Int): Int {\n          var i = foo ?: return bar\n          return i\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinInvalidBundleOrProperty",
+                "shortDescription": {
+                  "text": "Invalid property key"
+                },
+                "fullDescription": {
+                  "text": "Reports unresolved references to '.properties' file keys and resource bundles in Kotlin files.",
+                  "markdown": "Reports unresolved references to `.properties` file keys and resource bundles in Kotlin files."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "ideaSeverity": "ERROR",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UselessCallOnCollection",
+                "shortDescription": {
+                  "text": "Useless call on collection type"
+                },
+                "fullDescription": {
+                  "text": "Reports 'filter…' calls from the standard library on already filtered collections. Several functions from the standard library such as 'filterNotNull()' or 'filterIsInstance' have sense only when they are called on receivers that have types distinct from the resulting one. Otherwise, such calls can be omitted as the result will be the same. Remove redundant call quick-fix can be used to amend the code automatically. Example: 'fun test(list: List<String>) {\n      val x = list.filterNotNull() // quick-fix simplifies to 'list'\n      val y = list.filterIsInstance<String>() // quick-fix simplifies to 'list'\n  }'",
+                  "markdown": "Reports `filter...` calls from the standard library on already filtered collections.\n\nSeveral functions from the standard library such as `filterNotNull()` or `filterIsInstance`\nhave sense only when they are called on receivers that have types distinct from the resulting one. Otherwise,\nsuch calls can be omitted as the result will be the same.\n\n**Remove redundant call** quick-fix can be used to amend the code automatically.\n\nExample:\n\n\n      fun test(list: List<String>) {\n          val x = list.filterNotNull() // quick-fix simplifies to 'list'\n          val y = list.filterIsInstance<String>() // quick-fix simplifies to 'list'\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantRequireNotNullCall",
+                "shortDescription": {
+                  "text": "Redundant 'requireNotNull' or 'checkNotNull' call"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant 'requireNotNull' or 'checkNotNull' call on non-nullable expressions. Example: 'fun foo(i: Int) {\n      requireNotNull(i) // This 'i' is always not null, so this 'requireNotNull' call is redundant.\n      ...\n  }' After the quick-fix is applied: 'fun foo(i: Int) {\n      ...\n  }'",
+                  "markdown": "Reports redundant `requireNotNull` or `checkNotNull` call on non-nullable expressions.\n\n**Example:**\n\n\n      fun foo(i: Int) {\n          requireNotNull(i) // This 'i' is always not null, so this 'requireNotNull' call is redundant.\n          ...\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(i: Int) {\n          ...\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ObjectPropertyName",
+                "shortDescription": {
+                  "text": "Object property naming convention"
+                },
+                "fullDescription": {
+                  "text": "Reports properties that do not follow the naming conventions. The following properties are reported: Top-level properties Properties in objects and companion objects You can specify the required pattern in the inspection options. Recommended naming conventions: it has to start with an uppercase letter, use camel case and no underscores. Example: '// top-level property\n  val USER_NAME_FIELD = \"UserName\"\n  // top-level property holding reference to singleton object\n  val PersonComparator: Comparator<Person> = /*...*/\n\n  class Person {\n    companion object {\n      // property in companion object\n      val NO_NAME = Person()\n    }\n  }'",
+                  "markdown": "Reports properties that do not follow the naming conventions.\n\nThe following properties are reported:\n\n* Top-level properties\n* Properties in objects and companion objects\n\nYou can specify the required pattern in the inspection options.\n\n[Recommended naming conventions](https://kotlinlang.org/docs/coding-conventions.html#naming-rules): it has to start with an uppercase letter, use camel case and no underscores.\n\n**Example:**\n\n\n      // top-level property\n      val USER_NAME_FIELD = \"UserName\"\n      // top-level property holding reference to singleton object\n      val PersonComparator: Comparator<Person> = /*...*/\n\n      class Person {\n        companion object {\n          // property in companion object\n          val NO_NAME = Person()\n        }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Naming conventions",
+                      "index": 47,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PackageDirectoryMismatch",
+                "shortDescription": {
+                  "text": "Package name does not match containing directory"
+                },
+                "fullDescription": {
+                  "text": "Reports 'package' directives that do not match the location of the file.",
+                  "markdown": "Reports `package` directives that do not match the location of the file."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Java interop issues",
+                      "index": 54,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinCovariantEquals",
+                "shortDescription": {
+                  "text": "Covariant 'equals()'"
+                },
+                "fullDescription": {
+                  "text": "Reports 'equals()' that takes an argument type other than 'Any?' if the class does not have another 'equals()' that takes 'Any?' as its argument type. Example: 'class Foo {\n      fun equals(other: Foo?): Boolean {\n          return true\n      }\n  }' To fix the problem create 'equals()' method that takes an argument of type 'Any?'.",
+                  "markdown": "Reports `equals()` that takes an argument type other than `Any?` if the class does not have another `equals()` that takes `Any?` as its argument type.\n\n**Example:**\n\n\n      class Foo {\n          fun equals(other: Foo?): Boolean {\n              return true\n          }\n      }\n\nTo fix the problem create `equals()` method that takes an argument of type `Any?`."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceSizeZeroCheckWithIsEmpty",
+                "shortDescription": {
+                  "text": "Size zero check can be replaced with 'isEmpty()'"
+                },
+                "fullDescription": {
+                  "text": "Reports 'size == 0' checks on 'Collections/Array/String' that should be replaced with 'isEmpty()'. Using 'isEmpty()' makes your code simpler. The quick-fix replaces the size check with 'isEmpty()'. Example: 'fun foo() {\n      val arrayOf = arrayOf(1, 2, 3)\n      arrayOf.size == 0\n  }' After the quick-fix is applied: 'fun foo() {\n      val arrayOf = arrayOf(1, 2, 3)\n      arrayOf.isEmpty()\n  }'",
+                  "markdown": "Reports `size == 0` checks on `Collections/Array/String` that should be replaced with `isEmpty()`.\n\nUsing `isEmpty()` makes your code simpler.\n\nThe quick-fix replaces the size check with `isEmpty()`.\n\n**Example:**\n\n\n      fun foo() {\n          val arrayOf = arrayOf(1, 2, 3)\n          arrayOf.size == 0\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo() {\n          val arrayOf = arrayOf(1, 2, 3)\n          arrayOf.isEmpty()\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantEnumConstructorInvocation",
+                "shortDescription": {
+                  "text": "Redundant enum constructor invocation"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant constructor invocation on an enum entry. Example: 'enum class Baz(i: Int = 0) {\n      A(1),\n      B(),\n      C(),\n  }' After the quick-fix is applied: 'enum class Baz(i: Int = 0) {\n      A(1),\n      B,\n      C,\n  }'",
+                  "markdown": "Reports redundant constructor invocation on an enum entry.\n\n**Example:**\n\n\n      enum class Baz(i: Int = 0) {\n          A(1),\n          B(),\n          C(),\n      }\n\nAfter the quick-fix is applied:\n\n\n      enum class Baz(i: Int = 0) {\n          A(1),\n          B,\n          C,\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "DirectUseOfResultType",
+                "shortDescription": {
+                  "text": "Function returning Result directly"
+                },
+                "fullDescription": {
+                  "text": "Reports functions that use 'Result' as a return type. 'Result' should never be used as a return type. Throw an exception, use a nullable type, or use a domain-specific result class to indicate failure. Example: 'fun foo() = Result.success(true)'",
+                  "markdown": "Reports functions that use `Result` as a return type.\n\n\n`Result` should never be used as a return type.\nThrow an exception, use a nullable type, or use a domain-specific result class to indicate failure.\n\n**Example:**\n\n\n      fun foo() = Result.success(true)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "FakeJvmFieldConstant",
+                "shortDescription": {
+                  "text": "Kotlin non-const property used as Java constant"
+                },
+                "fullDescription": {
+                  "text": "Reports Kotlin properties that are not 'const' and used as Java annotation arguments. For example, a property with the '@JvmField' annotation has an initializer that can be evaluated at compile-time, and it has a primitive or 'String' type. Such properties have a 'ConstantValue' attribute in bytecode in Kotlin 1.1-1.2. This attribute allows javac to fold usages of the corresponding field and use that field in annotations. This can lead to incorrect behavior in the case of separate or incremental compilation in mixed Java/Kotlin code. This behavior is subject to change in Kotlin 1.3 (no 'ConstantValue' attribute any more). Example: Kotlin code in foo.kt file: 'annotation class Ann(val s: String)\n  @JvmField val importantString = \"important\"' Java code: 'public class JavaUser {\n      // This is dangerous\n      @Ann(s = FooKt.importantString)\n      public void foo() {}\n  }' To fix the problem replace the '@JvmField' annotation with the 'const' modifier on a relevant Kotlin property or inline it.",
+                  "markdown": "Reports Kotlin properties that are not `const` and used as Java annotation arguments.\n\n\nFor example, a property with the `@JvmField` annotation has an initializer that can be evaluated at compile-time,\nand it has a primitive or `String` type.\n\n\nSuch properties have a `ConstantValue` attribute in bytecode in Kotlin 1.1-1.2.\nThis attribute allows javac to fold usages of the corresponding field and use that field in annotations.\nThis can lead to incorrect behavior in the case of separate or incremental compilation in mixed Java/Kotlin code.\nThis behavior is subject to change in Kotlin 1.3 (no `ConstantValue` attribute any more).\n\n**Example:**\n\nKotlin code in foo.kt file:\n\n\n      annotation class Ann(val s: String)\n      @JvmField val importantString = \"important\"\n\nJava code:\n\n\n      public class JavaUser {\n          // This is dangerous\n          @Ann(s = FooKt.importantString)\n          public void foo() {}\n      }\n\nTo fix the problem replace the `@JvmField` annotation with the `const` modifier on a relevant Kotlin property or inline it."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Java interop issues",
+                      "index": 54,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "WhenWithOnlyElse",
+                "shortDescription": {
+                  "text": "'when' has only 'else' branch and can be simplified"
+                },
+                "fullDescription": {
+                  "text": "Reports 'when' expressions with only an 'else' branch that can be simplified. Simplify expression quick-fix can be used to amend the code automatically. Example: 'fun redundant() {\n      val x = when { // <== redundant, a quick-fix simplifies the when expression to \"val x = 1\"\n          else -> 1\n      }\n  }'",
+                  "markdown": "Reports `when` expressions with only an `else` branch that can be simplified.\n\n**Simplify expression** quick-fix can be used to amend the code automatically.\n\nExample:\n\n\n      fun redundant() {\n          val x = when { // <== redundant, a quick-fix simplifies the when expression to \"val x = 1\"\n              else -> 1\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "Reformat",
+                "shortDescription": {
+                  "text": "File is not formatted according to project settings"
+                },
+                "fullDescription": {
+                  "text": "Reports places that are not formatted according to the project settings. Use the 'Reformat Code' and 'Reformat File...' quick-fixes to format either the highlighted code block or the entire file accordingly.",
+                  "markdown": "Reports places that are not formatted according to the project settings.\n\nUse the 'Reformat Code' and 'Reformat File...' quick-fixes to format either the highlighted code block\nor the entire file accordingly."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinTestJUnit",
+                "shortDescription": {
+                  "text": "kotlin-test-junit could be used"
+                },
+                "fullDescription": {
+                  "text": "Reports usage of 'kotlin-test' and 'junit' dependency without 'kotlin-test-junit'. It is recommended to use 'kotlin-test-junit' dependency to work with Kotlin and JUnit.",
+                  "markdown": "Reports usage of `kotlin-test` and `junit` dependency without `kotlin-test-junit`.\n\nIt is recommended to use `kotlin-test-junit` dependency to work with Kotlin and JUnit."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SafeCastWithReturn",
+                "shortDescription": {
+                  "text": "Safe cast with 'return' should be replaced with 'if' type check"
+                },
+                "fullDescription": {
+                  "text": "Reports safe cast with 'return' that can be replaced with 'if' type check. Using corresponding functions makes your code simpler. The quick-fix replaces the safe cast with 'if' type check. Example: 'fun test(x: Any) {\n      x as? String ?: return\n  }' After the quick-fix is applied: 'fun test(x: Any) {\n      if (x !is String) return\n  }'",
+                  "markdown": "Reports safe cast with `return` that can be replaced with `if` type check.\n\nUsing corresponding functions makes your code simpler.\n\nThe quick-fix replaces the safe cast with `if` type check.\n\n**Example:**\n\n\n      fun test(x: Any) {\n          x as? String ?: return\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun test(x: Any) {\n          if (x !is String) return\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceAssertBooleanWithAssertEquality",
+                "shortDescription": {
+                  "text": "Assert boolean could be replaced with assert equality"
+                },
+                "fullDescription": {
+                  "text": "Reports calls to 'assertTrue()' and 'assertFalse()' that can be replaced with assert equality functions. 'assertEquals()', 'assertSame()', and their negating counterparts (-Not-) provide more informative messages on failure. Example: 'assertTrue(a == b)' After the quick-fix is applied: 'assertEquals(a, b)'",
+                  "markdown": "Reports calls to `assertTrue()` and `assertFalse()` that can be replaced with assert equality functions.\n\n\n`assertEquals()`, `assertSame()`, and their negating counterparts (-Not-) provide more informative messages on\nfailure.\n\n**Example:**\n\n      assertTrue(a == b)\n\nAfter the quick-fix is applied:\n\n      assertEquals(a, b)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceStringFormatWithLiteral",
+                "shortDescription": {
+                  "text": "'String.format' call can be replaced with string templates"
+                },
+                "fullDescription": {
+                  "text": "Reports 'String.format' calls that can be replaced with string templates. Using string templates makes your code simpler. The quick-fix replaces the call with a string template. Example: 'fun main() {\n      val id = \"abc\"\n      val date = \"123\"\n      val s = String.format(\"%s_%s_%s\", id, date, id)\n  }' After the quick-fix is applied: 'fun main() {\n      val id = \"abc\"\n      val date = \"123\"\n      val s = \"${id}_${date}_$id\"\n  }'",
+                  "markdown": "Reports `String.format` calls that can be replaced with string templates.\n\nUsing string templates makes your code simpler.\n\nThe quick-fix replaces the call with a string template.\n\n**Example:**\n\n\n      fun main() {\n          val id = \"abc\"\n          val date = \"123\"\n          val s = String.format(\"%s_%s_%s\", id, date, id)\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun main() {\n          val id = \"abc\"\n          val date = \"123\"\n          val s = \"${id}_${date}_$id\"\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceNotNullAssertionWithElvisReturn",
+                "shortDescription": {
+                  "text": "Not-null assertion can be replaced with 'return'"
+                },
+                "fullDescription": {
+                  "text": "Reports not-null assertion ('!!') calls that can be replaced with the elvis operator and return ('?: return'). A not-null assertion can lead to NPE (NullPointerException) that is not expected. Avoiding the use of '!!' is good practice. The quick-fix replaces the not-null assertion with 'return' or 'return null'. Example: 'fun test(number: Int?) {\n      val x = number!!\n  }' After the quick-fix is applied: 'fun test(number: Int?) {\n      val x = number ?: return\n  }'",
+                  "markdown": "Reports not-null assertion (`!!`) calls that can be replaced with the elvis operator and return (`?: return`).\n\nA not-null assertion can lead to NPE (NullPointerException) that is not expected. Avoiding the use of `!!` is good practice.\n\nThe quick-fix replaces the not-null assertion with `return` or `return null`.\n\n**Example:**\n\n\n      fun test(number: Int?) {\n          val x = number!!\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun test(number: Int?) {\n          val x = number ?: return\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceSubstringWithSubstringBefore",
+                "shortDescription": {
+                  "text": "'substring' call should be replaced with 'substringBefore'"
+                },
+                "fullDescription": {
+                  "text": "Reports calls like 's.substring(0, s.indexOf(x))' that can be replaced with 's.substringBefore(x)'. Using 'substringBefore()' makes your code simpler. The quick-fix replaces the 'substring' call with 'substringBefore'. Example: 'fun foo(s: String) {\n      s.substring(0, s.indexOf('x'))\n  }' After the quick-fix is applied: 'fun foo(s: String) {\n      s.substringBefore('x')\n  }'",
+                  "markdown": "Reports calls like `s.substring(0, s.indexOf(x))` that can be replaced with `s.substringBefore(x)`.\n\nUsing `substringBefore()` makes your code simpler.\n\nThe quick-fix replaces the `substring` call with `substringBefore`.\n\n**Example:**\n\n\n      fun foo(s: String) {\n          s.substring(0, s.indexOf('x'))\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(s: String) {\n          s.substringBefore('x')\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceWithOperatorAssignment",
+                "shortDescription": {
+                  "text": "Assignment can be replaced with operator assignment"
+                },
+                "fullDescription": {
+                  "text": "Reports modifications of variables with a simple assignment (such as 'y = y + x') that can be replaced with an operator assignment. The quick-fix replaces the assignment with an assignment operator. Example: 'fun foo() {\n      val list = mutableListOf(1, 2, 3)\n      list = list + 4\n  }' After the quick-fix is applied: 'fun foo() {\n      val list = mutableListOf(1, 2, 3)\n      list += 4\n  }'",
+                  "markdown": "Reports modifications of variables with a simple assignment (such as `y = y + x`) that can be replaced with an operator assignment.\n\nThe quick-fix replaces the assignment with an assignment operator.\n\n**Example:**\n\n\n      fun foo() {\n          val list = mutableListOf(1, 2, 3)\n          list = list + 4\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo() {\n          val list = mutableListOf(1, 2, 3)\n          list += 4\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UnusedSymbol",
+                "shortDescription": {
+                  "text": "Unused symbol"
+                },
+                "fullDescription": {
+                  "text": "Reports symbols that are not used or not reachable from entry points.",
+                  "markdown": "Reports symbols that are not used or not reachable from entry points."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceCollectionCountWithSize",
+                "shortDescription": {
+                  "text": "Collection count can be converted to size"
+                },
+                "fullDescription": {
+                  "text": "Reports calls to 'Collection<T>.count()'. This function call can be replaced with '.size'. '.size' form ensures that the operation is O(1) and won't allocate extra objects, whereas 'count()' could be confused with 'Iterable<T>.count()', which is O(n) and allocating. Example: 'fun foo() {\n      var list = listOf(1,2,3)\n      list.count() // replaceable 'count()'\n  }' After the quick-fix is applied: 'fun foo() {\n      var list = listOf(1,2,3)\n      list.size\n  }'",
+                  "markdown": "Reports calls to `Collection<T>.count()`.\n\n\nThis function call can be replaced with `.size`.\n\n\n`.size` form ensures that the operation is O(1) and won't allocate extra objects, whereas\n`count()` could be confused with `Iterable<T>.count()`, which is O(n) and allocating.\n\n\n**Example:**\n\n      fun foo() {\n          var list = listOf(1,2,3)\n          list.count() // replaceable 'count()'\n      }\n\nAfter the quick-fix is applied:\n\n      fun foo() {\n          var list = listOf(1,2,3)\n          list.size\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceArrayEqualityOpWithArraysEquals",
+                "shortDescription": {
+                  "text": "Arrays comparison via '==' and '!='"
+                },
+                "fullDescription": {
+                  "text": "Reports usages of '==' or '!=' operator for arrays that should be replaced with 'contentEquals()'. The '==' and '!='operators compare array references instead of their content. Examples: 'fun test() {\n      val a = arrayOf(1, 2, 3)\n      val b = arrayOf(1, 2, 3)\n      println(a == b) // references comparison\n  }' After the quick-fix is applied: 'fun test() {\n      val a = arrayOf(1, 2, 3)\n      val b = arrayOf(1, 2, 3)\n      println(a.contentEquals(b))\n  }'",
+                  "markdown": "Reports usages of `==` or `!=` operator for arrays that should be replaced with `contentEquals()`.\n\n\nThe `==` and `!=`operators compare array references instead of their content.\n\n**Examples:**\n\n      fun test() {\n          val a = arrayOf(1, 2, 3)\n          val b = arrayOf(1, 2, 3)\n          println(a == b) // references comparison\n      }\n\nAfter the quick-fix is applied:\n\n      fun test() {\n          val a = arrayOf(1, 2, 3)\n          val b = arrayOf(1, 2, 3)\n          println(a.contentEquals(b))\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "DeprecatedGradleDependency",
+                "shortDescription": {
+                  "text": "Deprecated library is used in Gradle"
+                },
+                "fullDescription": {
+                  "text": "Reports deprecated dependencies in Gradle build scripts. Example: 'dependencies {\n      compile \"org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.0\"\n  }' After the quick-fix applied: 'dependencies {\n      compile \"org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.0\"\n  }'",
+                  "markdown": "Reports deprecated dependencies in Gradle build scripts.\n\n**Example:**\n\n\n      dependencies {\n          compile \"org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.0\"\n      }\n\nAfter the quick-fix applied:\n\n\n      dependencies {\n          compile \"org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.0\"\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ConvertReferenceToLambda",
+                "shortDescription": {
+                  "text": "Can be replaced with lambda"
+                },
+                "fullDescription": {
+                  "text": "Reports a function reference expression that can be replaced with a function literal (lambda). Sometimes, passing a lambda looks more straightforward and more consistent with the rest of the code. Also, the fix might be handy if you need to replace a simple call with something more complex. Example: 'fun Int.isEven() = this % 2 == 0\n\n  fun example() {\n      val numbers = listOf(1, 2, 4, 7, 9, 10)\n      val evenNumbers = numbers.filter(Int::isEven)\n  }' After the quick-fix is applied: 'fun Int.isEven() = this % 2 == 0\n\n  fun example() {\n      val numbers = listOf(1, 2, 4, 7, 9, 10)\n      val evenNumbers = numbers.filter { it.isEven() }\n  }'",
+                  "markdown": "Reports a function reference expression that can be replaced with a function literal (lambda).\n\n\nSometimes, passing a lambda looks more straightforward and more consistent with the rest of the code.\nAlso, the fix might be handy if you need to replace a simple call with something more complex.\n\n**Example:**\n\n\n      fun Int.isEven() = this % 2 == 0\n\n      fun example() {\n          val numbers = listOf(1, 2, 4, 7, 9, 10)\n          val evenNumbers = numbers.filter(Int::isEven)\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun Int.isEven() = this % 2 == 0\n\n      fun example() {\n          val numbers = listOf(1, 2, 4, 7, 9, 10)\n          val evenNumbers = numbers.filter { it.isEven() }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UnlabeledReturnInsideLambda",
+                "shortDescription": {
+                  "text": "Unlabeled return inside lambda"
+                },
+                "fullDescription": {
+                  "text": "Reports unlabeled 'return' expressions inside inline lambda. Such expressions can be confusing because it might be unclear which scope belongs to 'return'. Change to return@… quick-fix can be used to amend the code automatically. Example: 'fun test(list: List<Int>) {\n      list.forEach {\n          // This return expression returns from the function test\n          // One can change it to return@forEach to change the scope\n          if (it == 10) return\n      }\n  }' After the quick-fix is applied: 'fun test(list: List<Int>) {\n      list.forEach {\n          if (it == 10) return@test\n      }\n  }'",
+                  "markdown": "Reports unlabeled `return` expressions inside inline lambda.\n\nSuch expressions can be confusing because it might be unclear which scope belongs to `return`.\n\n**Change to return@...** quick-fix can be used to amend the code automatically.\n\nExample:\n\n\n      fun test(list: List<Int>) {\n          list.forEach {\n              // This return expression returns from the function test\n              // One can change it to return@forEach to change the scope\n              if (it == 10) return\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun test(list: List<Int>) {\n          list.forEach {\n              if (it == 10) return@test\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "LateinitVarOverridesLateinitVar",
+                "shortDescription": {
+                  "text": "lateinit var property overrides lateinit var property"
+                },
+                "fullDescription": {
+                  "text": "Reports 'lateinit var' properties that override another 'lateinit var' property. A subclass instance will have two fields for the single property, and the one from the superclass will remain effectively unused. Example: open class BaseClass { open lateinit var name: String } class RealClass : BaseClass() { override lateinit var name: String } ''",
+                  "markdown": "Reports `lateinit var` properties that override another `lateinit var` property.\n\n\nA subclass instance will have two fields for the single property, and the one from the superclass will remain effectively unused.\n\n**Example:**\nopen class BaseClass { open lateinit var name: String } class RealClass : BaseClass() { override lateinit var name: String }\n\n```\n\n```"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "DifferentKotlinGradleVersion",
+                "shortDescription": {
+                  "text": "Kotlin Gradle and IDE plugins versions are different"
+                },
+                "fullDescription": {
+                  "text": "Reports that different IDE and Gradle plugin versions are used. This can cause inconsistencies between IDE and Gradle builds in error reporting or code behavior. Example: 'dependencies {\n    classpath \"org.jetbrains.kotlin:kotlin-gradle-plugin:0.0.1\"\n  }' To fix the problem change the kotlin gradle plugin version to match the version of kotlin that is bundled into the IDE plugin.",
+                  "markdown": "Reports that different IDE and Gradle plugin versions are used.\n\nThis can cause inconsistencies between IDE and Gradle builds in error reporting or code behavior.\n\n**Example:**\n\n\n      dependencies {\n        classpath \"org.jetbrains.kotlin:kotlin-gradle-plugin:0.0.1\"\n      }\n\nTo fix the problem change the kotlin gradle plugin version to match the version of kotlin that is bundled into the IDE plugin."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinEqualsBetweenInconvertibleTypes",
+                "shortDescription": {
+                  "text": "'equals()' between objects of inconvertible types"
+                },
+                "fullDescription": {
+                  "text": "Reports calls to 'equals()' where the receiver and the argument are of incompatible primitive, enum, or string types. While such a call might theoretically be useful, most likely it represents a bug. Example: '5.equals(\"\");'",
+                  "markdown": "Reports calls to `equals()` where the receiver and the argument are of incompatible primitive, enum, or string types.\n\nWhile such a call might theoretically be useful, most likely it represents a bug.\n\n**Example:**\n\n      5.equals(\"\");\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "JoinDeclarationAndAssignment",
+                "shortDescription": {
+                  "text": "Join declaration and assignment"
+                },
+                "fullDescription": {
+                  "text": "Reports property declarations that can be joined with the following assignment. Example: 'val x: String\n  x = System.getProperty(\"\")' The quick fix joins the declaration with the assignment: 'val x = System.getProperty(\"\")'",
+                  "markdown": "Reports property declarations that can be joined with the following assignment.\n\n**Example:**\n\n\n      val x: String\n      x = System.getProperty(\"\")\n\nThe quick fix joins the declaration with the assignment:\n\n\n      val x = System.getProperty(\"\")\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "HasPlatformType",
+                "shortDescription": {
+                  "text": "Function or property has platform type"
+                },
+                "fullDescription": {
+                  "text": "Reports functions and properties that have a platform type. To prevent unexpected errors, the type should be declared explicitly. Example: 'fun foo() = java.lang.String.valueOf(1)' The quick fix allows you to specify the return type: 'fun foo(): String = java.lang.String.valueOf(1)'",
+                  "markdown": "Reports functions and properties that have a platform type.\n\nTo prevent unexpected errors, the type should be declared explicitly.\n\n**Example:**\n\n\n      fun foo() = java.lang.String.valueOf(1)\n\nThe quick fix allows you to specify the return type:\n\n\n      fun foo(): String = java.lang.String.valueOf(1)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Java interop issues",
+                      "index": 54,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "DataClassPrivateConstructor",
+                "shortDescription": {
+                  "text": "Private data class constructor is exposed via the 'copy' method"
+                },
+                "fullDescription": {
+                  "text": "Reports the 'private' primary constructor in data classes. 'data' classes have a 'copy()' factory method that can be used similarly to a constructor. A constructor should not be marked as 'private' to provide enough safety. Example: 'data class User private constructor(val name: String)' A quick-fix changes the constructor visibility modifier to 'public': 'data class User(val name: String)'",
+                  "markdown": "Reports the `private` primary constructor in data classes.\n\n\n`data` classes have a `copy()` factory method that can be used similarly to a constructor.\nA constructor should not be marked as `private` to provide enough safety.\n\n**Example:**\n\n\n      data class User private constructor(val name: String)\n\nA quick-fix changes the constructor visibility modifier to `public`:\n\n\n      data class User(val name: String)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantInnerClassModifier",
+                "shortDescription": {
+                  "text": "Redundant 'inner' modifier"
+                },
+                "fullDescription": {
+                  "text": "Reports the 'inner' modifier on a class as redundant if it doesn't reference members of its outer class. Example: 'class Foo {\n      inner class InnerClass { // redundant `inner` modifier\n          fun hello() {\n              println(\"Hi!\")\n          }\n      }\n  }\n\n  class List {\n      val objects = Array<Any>(42) { Any() }\n\n      inner class Iterator { // Not redundant `inner` modifier\n          fun next(): Any {\n              return objects[0]\n          }\n      }\n  }' After the quick-fix is applied: 'class Foo {\n      class InnerClass { // redundant `inner` modifier\n          fun hello() {\n              println(\"Hi!\")\n          }\n      }\n  }\n\n  class List {\n      val objects = Array<Any>(42) { Any() }\n\n      inner class Iterator { // Not redundant `inner` modifier\n          fun next(): Any {\n              return objects[0]\n          }\n      }\n  }'",
+                  "markdown": "Reports the `inner` modifier on a class as redundant if it doesn't reference members of its outer class.\n\n**Example:**\n\n\n      class Foo {\n          inner class InnerClass { // redundant `inner` modifier\n              fun hello() {\n                  println(\"Hi!\")\n              }\n          }\n      }\n\n      class List {\n          val objects = Array<Any>(42) { Any() }\n\n          inner class Iterator { // Not redundant `inner` modifier\n              fun next(): Any {\n                  return objects[0]\n              }\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      class Foo {\n          class InnerClass { // redundant `inner` modifier\n              fun hello() {\n                  println(\"Hi!\")\n              }\n          }\n      }\n\n      class List {\n          val objects = Array<Any>(42) { Any() }\n\n          inner class Iterator { // Not redundant `inner` modifier\n              fun next(): Any {\n                  return objects[0]\n              }\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "JavaCollectionsStaticMethodOnImmutableList",
+                "shortDescription": {
+                  "text": "Call of Java mutator method on immutable Kotlin collection"
+                },
+                "fullDescription": {
+                  "text": "Reports Java mutator methods calls (like 'fill', 'reverse', 'shuffle', 'sort') on an immutable Kotlin collection. This can lead to 'UnsupportedOperationException' at runtime. Example: 'import java.util.Collections\n\n  fun test() {\n      val immutableList = listOf(1, 2)\n      Collections.reverse(immutableList)\n  }' To fix the problem make the list mutable.",
+                  "markdown": "Reports Java mutator methods calls (like `fill`, `reverse`, `shuffle`, `sort`) on an immutable Kotlin collection.\n\nThis can lead to `UnsupportedOperationException` at runtime.\n\n**Example:**\n\n\n      import java.util.Collections\n\n      fun test() {\n          val immutableList = listOf(1, 2)\n          Collections.reverse(immutableList)\n      }\n\nTo fix the problem make the list mutable."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Java interop issues",
+                      "index": 54,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "MavenCoroutinesDeprecation",
+                "shortDescription": {
+                  "text": "Incompatible kotlinx.coroutines dependency is used with Kotlin 1.3+ in Maven"
+                },
+                "fullDescription": {
+                  "text": "Reports kotlinx.coroutines library dependencies in Maven that should be updated in order to be compatible with Kotlin 1.3 and later.",
+                  "markdown": "Reports **kotlinx.coroutines** library dependencies in Maven that should be updated in order to be compatible with Kotlin 1.3 and later."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "ideaSeverity": "ERROR",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Migration/Maven",
+                      "index": 119,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "NullableBooleanElvis",
+                "shortDescription": {
+                  "text": "Equality check can be used instead of elvis for nullable boolean check"
+                },
+                "fullDescription": {
+                  "text": "Reports cases when an equality check should be used instead of the elvis operator. Example: 'fun check(a: Boolean? == null) {\n    if (a ?: false) throw IllegalStateException()\n}' After the quick-fix is applied: 'fun check(a: Boolean? == null) {\n    if (a == true) throw IllegalStateException()\n}'",
+                  "markdown": "Reports cases when an equality check should be used instead of the elvis operator.\n\n**Example:**\n\n\n    fun check(a: Boolean? == null) {\n        if (a ?: false) throw IllegalStateException()\n    }\n\nAfter the quick-fix is applied:\n\n\n    fun check(a: Boolean? == null) {\n        if (a == true) throw IllegalStateException()\n    }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "DeprecatedMavenDependency",
+                "shortDescription": {
+                  "text": "Deprecated library is used in Maven"
+                },
+                "fullDescription": {
+                  "text": "Reports deprecated maven dependency. Example: '<dependencies>\n    <dependency>\n        <groupId>org.jetbrains.kotlin</groupId>\n        <artifactId>kotlin-stdlib-jre7</artifactId>\n        <version>${kotlin.version}</version>\n    </dependency>\n  </dependencies>' The quick fix changes the deprecated dependency to a maintained one: '<dependencies>\n    <dependency>\n        <groupId>org.jetbrains.kotlin</groupId>\n        <artifactId>kotlin-stdlib-jdk7</artifactId>\n        <version>${kotlin.version}</version>\n    </dependency>\n  </dependencies>'",
+                  "markdown": "Reports deprecated maven dependency.\n\n**Example:**\n\n\n      <dependencies>\n        <dependency>\n            <groupId>org.jetbrains.kotlin</groupId>\n            <artifactId>kotlin-stdlib-jre7</artifactId>\n            <version>${kotlin.version}</version>\n        </dependency>\n      </dependencies>\n\nThe quick fix changes the deprecated dependency to a maintained one:\n\n\n       <dependencies>\n        <dependency>\n            <groupId>org.jetbrains.kotlin</groupId>\n            <artifactId>kotlin-stdlib-jdk7</artifactId>\n            <version>${kotlin.version}</version>\n        </dependency>\n      </dependencies>\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UnnecessaryVariable",
+                "shortDescription": {
+                  "text": "Unnecessary local variable"
+                },
+                "fullDescription": {
+                  "text": "Reports local variables that used only in the very next 'return' statement or exact copies of other variables. Such variables can be safely inlined to make the code more clear.",
+                  "markdown": "Reports local variables that used only in the very next `return` statement or exact copies of other variables.\n\nSuch variables can be safely inlined to make the code more clear."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantEmptyInitializerBlock",
+                "shortDescription": {
+                  "text": "Redundant empty initializer block"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant empty initializer blocks. Example: 'class Foo {\n      init {\n          // Empty init block\n      }\n  }' After the quick-fix is applied: 'class Foo {\n  }'",
+                  "markdown": "Reports redundant empty initializer blocks.\n\n**Example:**\n\n\n      class Foo {\n          init {\n              // Empty init block\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      class Foo {\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "GradleKotlinxCoroutinesDeprecation",
+                "shortDescription": {
+                  "text": "Incompatible kotlinx.coroutines dependency is used with Kotlin 1.3+ in Gradle"
+                },
+                "fullDescription": {
+                  "text": "Reports 'kotlinx.coroutines' library dependencies in Gradle that should be updated to be compatible with Kotlin 1.3+. Example: 'dependencies {\n      implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.0.1'\n  }' The quick fix changes the 'kotlinx.coroutines' library version to a compatible with Kotlin 1.3: 'dependencies {\n      implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.27.0-eap13'\n  }'",
+                  "markdown": "Reports `kotlinx.coroutines` library dependencies in Gradle that should be updated to be compatible with Kotlin 1.3+.\n\n**Example:**\n\n\n      dependencies {\n          implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.0.1'\n      }\n\nThe quick fix changes the `kotlinx.coroutines` library version to a compatible with Kotlin 1.3:\n\n\n      dependencies {\n          implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.27.0-eap13'\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "ideaSeverity": "ERROR",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Migration/Gradle",
+                      "index": 127,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantWith",
+                "shortDescription": {
+                  "text": "Redundant 'with' call"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant 'with' function calls that don't access anything from the receiver. Examples: 'class MyClass {\n      fun f(): String = \"\"\n  }\n\n  fun testRedundant() {\n      with(c) { // <== 'with' is redundant since 'c' isn't used\n          println(\"1\")\n      }\n  }\n\n  fun testOk() {\n      val c = MyClass()\n      with(c) { // <== OK because 'f()' is effectively 'c.f()'\n          println(f())\n      }\n  }'",
+                  "markdown": "Reports redundant `with` function calls that don't access anything from the receiver.\n\n**Examples:**\n\n\n      class MyClass {\n          fun f(): String = \"\"\n      }\n\n      fun testRedundant() {\n          with(c) { // <== 'with' is redundant since 'c' isn't used\n              println(\"1\")\n          }\n      }\n\n      fun testOk() {\n          val c = MyClass()\n          with(c) { // <== OK because 'f()' is effectively 'c.f()'\n              println(f())\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "WarningOnMainUnusedParameterMigration",
+                "shortDescription": {
+                  "text": "Unused `args` on `main` since 1.4"
+                },
+                "fullDescription": {
+                  "text": "Reports 'main' function with an unused single parameter. Since Kotlin 1.4, it is possible to use the 'main' function without parameter as the entry point to the Kotlin program. The compiler reports a warning for the 'main' function with an unused parameter.",
+                  "markdown": "Reports `main` function with an unused single parameter.\n\nSince Kotlin 1.4, it is possible to use the `main` function without parameter as the entry point to the Kotlin program.\nThe compiler reports a warning for the `main` function with an unused parameter."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Migration",
+                      "index": 118,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantLabelMigration",
+                "shortDescription": {
+                  "text": "Redundant label"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant labels which cause compilation errors since Kotlin 1.4. Since Kotlin 1.0, one can mark any statement with a label: 'fun foo() {\n    L1@ val x = L2@bar()\n  }' However, these labels can be referenced only in a limited number of ways: break / continue from a loop non-local return from an inline lambda or inline anonymous function sssss Such labels are prohibited since Kotlin 1.4. This inspection only reports if the Kotlin language level of the project or module is 1.4 or higher.",
+                  "markdown": "Reports redundant labels which cause compilation errors since Kotlin 1.4.\n\nSince Kotlin 1.0, one can mark any statement with a label:\n\n\n      fun foo() {\n        L1@ val x = L2@bar()\n      }\n\nHowever, these labels can be referenced only in a limited number of ways:\n\n* break / continue from a loop\n* non-local return from an inline lambda or inline anonymous function\nsssss\n\nSuch labels are prohibited since Kotlin 1.4.\n\nThis inspection only reports if the Kotlin language level of the project or module is 1.4 or higher."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Migration",
+                      "index": 118,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceNegatedIsEmptyWithIsNotEmpty",
+                "shortDescription": {
+                  "text": "Negated call can be simplified"
+                },
+                "fullDescription": {
+                  "text": "Reports negation 'isEmpty()' and 'isNotEmpty()' for collections and 'String', or 'isBlank()' and 'isNotBlank()' for 'String'. Using corresponding functions makes your code simpler. The quick-fix replaces the negation call with the corresponding call from the Standard Library. Example: 'fun main() {\n      val list = listOf(1,2,3)\n      if (!list.isEmpty()) {\n          // do smth\n      }\n  }' After the quick-fix is applied: 'fun main() {\n      val list = listOf(1,2,3)\n      if (list.isNotEmpty()) {\n          // do smth\n      }\n  }'",
+                  "markdown": "Reports negation `isEmpty()` and `isNotEmpty()` for collections and `String`, or `isBlank()` and `isNotBlank()` for `String`.\n\nUsing corresponding functions makes your code simpler.\n\nThe quick-fix replaces the negation call with the corresponding call from the Standard Library.\n\n**Example:**\n\n\n      fun main() {\n          val list = listOf(1,2,3)\n          if (!list.isEmpty()) {\n              // do smth\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun main() {\n          val list = listOf(1,2,3)\n          if (list.isNotEmpty()) {\n              // do smth\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "DelegationToVarProperty",
+                "shortDescription": {
+                  "text": "Delegating to 'var' property"
+                },
+                "fullDescription": {
+                  "text": "Reports interface delegation to a 'var' property. Only initial value of a property is used for delegation, any later assignments do not affect it. Example: 'class Example(var text: CharSequence): CharSequence by text' A quick-fix replaces a property with immutable one: 'class Example(val text: CharSequence): CharSequence by text' Alternative way, if you rely on mutability for some reason: 'class Example(text: CharSequence): CharSequence by text {\n      var text = text\n  }'",
+                  "markdown": "Reports interface delegation to a `var` property.\n\nOnly initial value of a property is used for delegation, any later assignments do not affect it.\n\n**Example:**\n\n\n      class Example(var text: CharSequence): CharSequence by text\n\nA quick-fix replaces a property with immutable one:\n\n\n      class Example(val text: CharSequence): CharSequence by text\n\nAlternative way, if you rely on mutability for some reason:\n\n\n      class Example(text: CharSequence): CharSequence by text {\n          var text = text\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ConstantConditionIf",
+                "shortDescription": {
+                  "text": "Condition of 'if' expression is constant"
+                },
+                "fullDescription": {
+                  "text": "Reports 'if' expressions that have 'true' or 'false' constant literal condition and can be simplified. While occasionally intended, this construction is confusing and often the result of a typo or previous refactoring. Example: 'fun example() {\n      if (true) {\n          throw IllegalStateException(\"Unexpected state\")\n      }\n  }' A quick-fix removes the 'if' condition: 'fun example() {\n      throw IllegalStateException(\"Unexpected state\")\n  }'",
+                  "markdown": "Reports `if` expressions that have `true` or `false` constant literal condition and can be simplified.\n\nWhile occasionally intended, this construction is confusing and often the result of a typo\nor previous refactoring.\n\n**Example:**\n\n\n      fun example() {\n          if (true) {\n              throw IllegalStateException(\"Unexpected state\")\n          }\n      }\n\nA quick-fix removes the `if` condition:\n\n\n      fun example() {\n          throw IllegalStateException(\"Unexpected state\")\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantLambdaArrow",
+                "shortDescription": {
+                  "text": "Redundant lambda arrow"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant lambda arrows in lambdas without parameters. Example: 'fun foo(f: () -> Unit) = f()\n\n  fun bar() {\n      foo { -> println(\"Hi!\") }\n  }' After the quick-fix is applied: 'fun foo(f: () -> Unit) = f()\n\n  fun bar() {\n      foo { println(\"Hi!\") }\n  }'",
+                  "markdown": "Reports redundant lambda arrows in lambdas without parameters.\n\n**Example:**\n\n\n      fun foo(f: () -> Unit) = f()\n\n      fun bar() {\n          foo { -\\> println(\"Hi!\") }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(f: () -> Unit) = f()\n\n      fun bar() {\n          foo { println(\"Hi!\") }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinInternalInJava",
+                "shortDescription": {
+                  "text": "Usage of Kotlin internal declarations from Java"
+                },
+                "fullDescription": {
+                  "text": "Reports usages of Kotlin 'internal' declarations in Java code that is located in a different module. The 'internal' keyword is designed to restrict access to a class, function, or property from other modules. Due to JVM limitations, 'internal' classes, functions, and properties can still be accessed from outside Kotlin, which may later lead to compatibility problems.",
+                  "markdown": "Reports usages of Kotlin `internal` declarations in Java code that is located in a different module.\n\n\nThe `internal` keyword is designed to restrict access to a class, function, or property from other modules.\nDue to JVM limitations, `internal` classes, functions, and properties can still be\naccessed from outside Kotlin, which may later lead to compatibility problems."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "ideaSeverity": "ERROR",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Java interop issues",
+                      "index": 54,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UseWithIndex",
+                "shortDescription": {
+                  "text": "Manually incremented index variable can be replaced with use of 'withIndex()'"
+                },
+                "fullDescription": {
+                  "text": "Reports 'for' loops with a manually incremented index variable. 'for' loops with a manually incremented index variable can be simplified with the 'withIndex()' function. Use withIndex() instead of manual index increment quick-fix can be used to amend the code automatically. Example: 'fun foo(list: List<String>): Int? {\n      var index = 0\n      for (s in list) { <== can be simplified\n          val x = s.length * index\n          index++\n          if (x > 0) return x\n      }\n      return null\n  }' After the quick-fix is applied: 'fun foo(list: List<String>): Int? {\n      for ((index, s) in list.withIndex()) {\n          val x = s.length * index\n          if (x > 0) return x\n      }\n      return null\n  }'",
+                  "markdown": "Reports `for` loops with a manually incremented index variable.\n\n`for` loops with a manually incremented index variable can be simplified with the `withIndex()` function.\n\n**Use withIndex() instead of manual index increment** quick-fix can be used to amend the code automatically.\n\nExample:\n\n\n      fun foo(list: List<String>): Int? {\n          var index = 0\n          for (s in list) { <== can be simplified\n              val x = s.length * index\n              index++\n              if (x > 0) return x\n          }\n          return null\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(list: List<String>): Int? {\n          for ((index, s) in list.withIndex()) {\n              val x = s.length * index\n              if (x > 0) return x\n          }\n          return null\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ImplicitThis",
+                "shortDescription": {
+                  "text": "Implicit 'this'"
+                },
+                "fullDescription": {
+                  "text": "Reports usages of implicit this. Example: 'class Foo {\n      fun s() = \"\"\n\n      fun test() {\n          s()\n      }\n  }' The quick fix specifies this explicitly: 'class Foo {\n      fun s() = \"\"\n\n      fun test() {\n          this.s()\n      }\n  }'",
+                  "markdown": "Reports usages of implicit **this** .\n\n**Example:**\n\n\n      class Foo {\n          fun s() = \"\"\n\n          fun test() {\n              s()\n          }\n      }\n\nThe quick fix specifies **this** explicitly:\n\n\n      class Foo {\n          fun s() = \"\"\n\n          fun test() {\n              this.s()\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinCatchMayIgnoreException",
+                "shortDescription": {
+                  "text": "'catch' block may ignore exception"
+                },
+                "fullDescription": {
+                  "text": "Reports 'catch' blocks that are empty or may ignore an exception. While occasionally intended, empty 'catch' blocks may complicate debugging. Also, ignoring a 'catch' parameter might be wrong. The inspection won't report any 'catch' parameters named 'ignore', 'ignored', or '_'. You can use a quick-fix to change the exception name to '_'. Example: 'try {\n    throwingMethod()\n  } catch (ex: IOException) {\n\n  }' After the quick-fix is applied: 'try {\n    throwingMethod()\n  } catch (_: IOException) {\n\n  }' Use the Do not warn when 'catch' block contains a comment option to ignore 'catch' blocks with comments.",
+                  "markdown": "Reports `catch` blocks that are empty or may ignore an exception.\n\nWhile occasionally intended, empty `catch` blocks may complicate debugging.\nAlso, ignoring a `catch` parameter might be wrong.\n\n\nThe inspection won't report any `catch` parameters named `ignore`, `ignored`, or `_`.\n\n\nYou can use a quick-fix to change the exception name to `_`.\n\n**Example:**\n\n\n      try {\n        throwingMethod()\n      } catch (ex: IOException) {\n\n      }\n\nAfter the quick-fix is applied:\n\n\n      try {\n        throwingMethod()\n      } catch (_: IOException) {\n\n      }\n\nUse the **Do not warn when 'catch' block contains a comment** option to ignore `catch` blocks with comments."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "DifferentStdlibGradleVersion",
+                "shortDescription": {
+                  "text": "Kotlin library and Gradle plugin versions are different"
+                },
+                "fullDescription": {
+                  "text": "Reports different Kotlin stdlib and compiler versions. Example: 'dependencies {\n    classpath \"org.jetbrains.kotlin:kotlin-stdlib:0.0.1\"\n  }' To fix the problem change the kotlin stdlib version to match the kotlin compiler version.",
+                  "markdown": "Reports different Kotlin stdlib and compiler versions.\n\n**Example:**\n\n\n      dependencies {\n        classpath \"org.jetbrains.kotlin:kotlin-stdlib:0.0.1\"\n      }\n\nTo fix the problem change the kotlin stdlib version to match the kotlin compiler version."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CanBeVal",
+                "shortDescription": {
+                  "text": "Local 'var' is never modified and can be declared as 'val'"
+                },
+                "fullDescription": {
+                  "text": "Reports local variables declared with the 'var' keyword that are never modified. Kotlin encourages to declare practically immutable variables using the 'val' keyword, ensuring that their value will never change. Example: 'fun example() {\n      var primeNumbers = listOf(1, 2, 3, 5, 7, 11, 13)\n      var fibonacciNumbers = listOf(1, 1, 2, 3, 5, 8, 13)\n      print(\"Same numbers: \" + primeNumbers.intersect(fibonacciNumbers))\n  }' A quick-fix replaces the 'var' keyword with 'val': 'fun example() {\n      val primeNumbers = listOf(1, 2, 3, 5, 7, 11, 13)\n      val fibonacciNumbers = listOf(1, 1, 2, 3, 5, 8, 13)\n      print(\"Same numbers: \" + primeNumbers.intersect(fibonacciNumbers))\n  }'",
+                  "markdown": "Reports local variables declared with the `var` keyword that are never modified.\n\nKotlin encourages to declare practically immutable variables using the `val` keyword, ensuring that their value will never change.\n\n**Example:**\n\n\n      fun example() {\n          var primeNumbers = listOf(1, 2, 3, 5, 7, 11, 13)\n          var fibonacciNumbers = listOf(1, 1, 2, 3, 5, 8, 13)\n          print(\"Same numbers: \" + primeNumbers.intersect(fibonacciNumbers))\n      }\n\nA quick-fix replaces the `var` keyword with `val`:\n\n\n      fun example() {\n          val primeNumbers = listOf(1, 2, 3, 5, 7, 11, 13)\n          val fibonacciNumbers = listOf(1, 1, 2, 3, 5, 8, 13)\n          print(\"Same numbers: \" + primeNumbers.intersect(fibonacciNumbers))\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceWithIgnoreCaseEquals",
+                "shortDescription": {
+                  "text": "Should be replaced with 'equals(..., ignoreCase = true)'"
+                },
+                "fullDescription": {
+                  "text": "Reports case-insensitive comparisons that can be replaced with 'equals(..., ignoreCase = true)'. By using 'equals()' you don't have to allocate extra strings with 'toLowerCase()' or 'toUpperCase()' to compare strings. The quick-fix replaces the case-insensitive comparison that uses 'toLowerCase()' or 'toUpperCase()' with 'equals(..., ignoreCase = true)'. Note: May change semantics for some locales. Example: 'fun main() {\n      val a = \"KoTliN\"\n      val b = \"KOTLIN\"\n      println(a.toLowerCase() == b.toLowerCase())\n  }' After the quick-fix is applied: 'fun main() {\n      val a = \"KoTliN\"\n      val b = \"KOTLIN\"\n      println(a.equals(b, ignoreCase = true))\n  }'",
+                  "markdown": "Reports case-insensitive comparisons that can be replaced with `equals(..., ignoreCase = true)`.\n\nBy using `equals()` you don't have to allocate extra strings with `toLowerCase()` or `toUpperCase()` to compare strings.\n\nThe quick-fix replaces the case-insensitive comparison that uses `toLowerCase()` or `toUpperCase()` with `equals(..., ignoreCase = true)`.\n\n**Note:** May change semantics for some locales.\n\n**Example:**\n\n\n      fun main() {\n          val a = \"KoTliN\"\n          val b = \"KOTLIN\"\n          println(a.toLowerCase() == b.toLowerCase())\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun main() {\n          val a = \"KoTliN\"\n          val b = \"KOTLIN\"\n          println(a.equals(b, ignoreCase = true))\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceSubstringWithSubstringAfter",
+                "shortDescription": {
+                  "text": "'substring' call should be replaced with 'substringAfter'"
+                },
+                "fullDescription": {
+                  "text": "Reports calls like 's.substring(s.indexOf(x))' that can be replaced with 's.substringAfter(x)'. Using 's.substringAfter(x)' makes your code simpler. The quick-fix replaces the 'substring' call with 'substringAfter'. Example: 'fun foo(s: String) {\n      s.substring(s.indexOf('x'))\n  }' After the quick-fix is applied: 'fun foo(s: String) {\n      s.substringAfter('x')\n  }'",
+                  "markdown": "Reports calls like `s.substring(s.indexOf(x))` that can be replaced with `s.substringAfter(x)`.\n\nUsing `s.substringAfter(x)` makes your code simpler.\n\nThe quick-fix replaces the `substring` call with `substringAfter`.\n\n**Example:**\n\n\n      fun foo(s: String) {\n          s.substring(s.indexOf('x'))\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(s: String) {\n          s.substringAfter('x')\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantCompanionReference",
+                "shortDescription": {
+                  "text": "Redundant 'Companion' reference"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant 'Companion' reference. Example: 'class A {\n      companion object {\n          fun create() = A()\n      }\n  }\n  fun test() {\n      val s = A.Companion.create()\n  }' After the quick-fix is applied: 'class A {\n      companion object {\n          fun create() = A()\n      }\n  }\n  fun test() {\n      val s = A.create()\n  }'",
+                  "markdown": "Reports redundant `Companion` reference.\n\n**Example:**\n\n\n      class A {\n          companion object {\n              fun create() = A()\n          }\n      }\n      fun test() {\n          val s = A.Companion.create()\n      }\n\nAfter the quick-fix is applied:\n\n\n      class A {\n          companion object {\n              fun create() = A()\n          }\n      }\n      fun test() {\n          val s = A.create()\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KDocUnresolvedReference",
+                "shortDescription": {
+                  "text": "Unresolved reference in KDoc"
+                },
+                "fullDescription": {
+                  "text": "Reports unresolved references in KDoc comments. Example: '/**\n   * [unresolvedLink]\n   */\n  fun foo() {}' To fix the problem make the link valid.",
+                  "markdown": "Reports unresolved references in KDoc comments.\n\n**Example:**\n\n\n      /**\n       * [unresolvedLink]\n       */\n      fun foo() {}\n\nTo fix the problem make the link valid."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "NestedLambdaShadowedImplicitParameter",
+                "shortDescription": {
+                  "text": "Nested lambda has shadowed implicit parameter"
+                },
+                "fullDescription": {
+                  "text": "Reports nested lambdas with shadowed implicit parameters. Example: 'fun foo(listOfLists: List<List<String>>) {\n  listOfLists.forEach {\n    it.forEach {\n      println(it)\n    }\n  }\n}' After the quick-fix is applied: 'fun foo(listOfLists: List<List<String>>) {\n  listOfLists.forEach {\n    it.forEach { it1 ->\n      println(it1)\n    }\n  }\n}'",
+                  "markdown": "Reports nested lambdas with shadowed implicit parameters.\n\n**Example:**\n\n\n    fun foo(listOfLists: List<List<String>>) {\n      listOfLists.forEach {\n        it.forEach {\n          println(it)\n        }\n      }\n    }\n\nAfter the quick-fix is applied:\n\n\n    fun foo(listOfLists: List<List<String>>) {\n      listOfLists.forEach {\n        it.forEach { it1 ->\n          println(it1)\n        }\n      }\n    }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantSamConstructor",
+                "shortDescription": {
+                  "text": "Redundant SAM constructor"
+                },
+                "fullDescription": {
+                  "text": "Reports SAM (Single Abstract Method) constructor usages which can be replaced with lambdas. Example: 'fun main() {\n      foo(Runnable { println(\"Hi!\") })\n  }\n\n  fun foo(other: Runnable) {}' After the quick-fix is applied: 'fun main() {\n      foo( { println(\"Hi!\") })\n  }\n\n  fun foo(other: Runnable) {}'",
+                  "markdown": "Reports SAM (Single Abstract Method) constructor usages which can be replaced with lambdas.\n\n**Example:**\n\n\n      fun main() {\n          foo(Runnable { println(\"Hi!\") })\n      }\n\n      fun foo(other: Runnable) {}\n\nAfter the quick-fix is applied:\n\n\n      fun main() {\n          foo( { println(\"Hi!\") })\n      }\n\n      fun foo(other: Runnable) {}\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "InconsistentCommentForJavaParameter",
+                "shortDescription": {
+                  "text": "Inconsistent comment for java parameter"
+                },
+                "fullDescription": {
+                  "text": "Reports inconsistent parameter name for java method specified in a comment block. Examples: '// Java\n  public class JavaService {\n      public void invoke(String command) {}\n  }' '// Kotlin\n  fun main() {\n      JavaService().invoke(/* name = */ \"fix\")\n  }' The quick fix corrects parameter name in a comment block: 'fun main() {\n      JavaService().invoke(/* command = */ \"fix\")\n  }'",
+                  "markdown": "Reports inconsistent parameter name for **java** method specified in a comment block.\n\n**Examples:**\n\n\n      // Java\n      public class JavaService {\n          public void invoke(String command) {}\n      }\n\n\n      // Kotlin\n      fun main() {\n          JavaService().invoke(/* name = */ \"fix\")\n      }\n\nThe quick fix corrects parameter name in a comment block:\n\n\n      fun main() {\n          JavaService().invoke(/* command = */ \"fix\")\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Naming conventions",
+                      "index": 47,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveRedundantCallsOfConversionMethods",
+                "shortDescription": {
+                  "text": "Redundant call of conversion method"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant calls to conversion methods (for example, 'toString()' on a 'String' or 'toDouble()' on a 'Double'). Use the 'Remove redundant calls of the conversion method' quick-fix to clean up the code.",
+                  "markdown": "Reports redundant calls to conversion methods (for example, `toString()` on a `String` or `toDouble()` on a `Double`).\n\nUse the 'Remove redundant calls of the conversion method' quick-fix to clean up the code."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinThrowableNotThrown",
+                "shortDescription": {
+                  "text": "Throwable not thrown"
+                },
+                "fullDescription": {
+                  "text": "Reports instantiations of 'Throwable' or its subclasses, when the created 'Throwable' is never actually thrown. The reported code indicates mistakes that are hard to catch in tests. Also, this inspection reports method calls that return instances of 'Throwable' or its subclasses, when the resulting 'Throwable' instance is not thrown. Example: 'fun check(condition: Boolean) {\n      if (!condition) /* throw is missing here */ IllegalArgumentException(\"condition is not met\");\n  }\n\n  fun createError() = RuntimeException()\n\n  fun foo() {\n      /* throw is missing here */ createError()\n  }'",
+                  "markdown": "Reports instantiations of `Throwable` or its subclasses, when the created `Throwable` is never actually thrown.\n\nThe reported code indicates mistakes that are hard to catch in tests.\n\n\nAlso, this inspection reports method calls that return instances of `Throwable` or its subclasses,\nwhen the resulting `Throwable` instance is not thrown.\n\n**Example:**\n\n\n      fun check(condition: Boolean) {\n          if (!condition) /* throw is missing here */ IllegalArgumentException(\"condition is not met\");\n      }\n\n      fun createError() = RuntimeException()\n\n      fun foo() {\n          /* throw is missing here */ createError()\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinSealedInheritorsInJava",
+                "shortDescription": {
+                  "text": "Inheritance of Kotlin sealed interface/class from Java"
+                },
+                "fullDescription": {
+                  "text": "Reports attempts to inherit from Kotlin sealed interfaces or classes in Java code. Example: '// Kotlin file: MathExpression.kt\n\nsealed class MathExpression\n\ndata class Const(val number: Double) : MathExpression()\ndata class Sum(val e1: MathExpression, val e2: MathExpression) : MathExpression()' '// Java file: NotANumber.java\n\npublic class NotANumber extends MathExpression {\n}'",
+                  "markdown": "Reports attempts to inherit from Kotlin sealed interfaces or classes in Java code.\n\n**Example:**\n\n\n    // Kotlin file: MathExpression.kt\n\n    sealed class MathExpression\n\n    data class Const(val number: Double) : MathExpression()\n    data class Sum(val e1: MathExpression, val e2: MathExpression) : MathExpression()\n\n\n    // Java file: NotANumber.java\n\n    public class NotANumber extends MathExpression {\n    }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "ideaSeverity": "ERROR",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Java interop issues",
+                      "index": 54,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SimplifyNegatedBinaryExpression",
+                "shortDescription": {
+                  "text": "Negated boolean expression can be simplified"
+                },
+                "fullDescription": {
+                  "text": "Reports negated binary expressions that can be simplified. The quick-fix simplifies the binary expression. Example: 'fun test(n: Int) {\n      !(0 == 1)\n  }' After the quick-fix is applied: 'fun test(n: Int) {\n      0 != 1\n  }'",
+                  "markdown": "Reports negated binary expressions that can be simplified.\n\nThe quick-fix simplifies the binary expression.\n\n**Example:**\n\n\n      fun test(n: Int) {\n          !(0 == 1)\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun test(n: Int) {\n          0 != 1\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "MemberVisibilityCanBePrivate",
+                "shortDescription": {
+                  "text": "Class member can have 'private' visibility"
+                },
+                "fullDescription": {
+                  "text": "Reports declarations that can be made 'private' to follow the encapsulation principle. Example: 'class Service(val url: String) {\n    fun connect(): URLConnection = URL(url).openConnection()\n}' After the quick-fix is applied (considering there are no usages of 'url' outside of 'Service' class): 'class Service(private val url: String) {\n    fun connect(): URLConnection = URL(url).openConnection()\n}'",
+                  "markdown": "Reports declarations that can be made `private` to follow the encapsulation principle.\n\n**Example:**\n\n\n    class Service(val url: String) {\n        fun connect(): URLConnection = URL(url).openConnection()\n    }\n\nAfter the quick-fix is applied (considering there are no usages of `url` outside of `Service` class):\n\n\n    class Service(private val url: String) {\n        fun connect(): URLConnection = URL(url).openConnection()\n    }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SelfAssignment",
+                "shortDescription": {
+                  "text": "Redundant assignment"
+                },
+                "fullDescription": {
+                  "text": "Reports assignments of a variable to itself. The quick-fix removes the redundant assignment. Example: 'fun test() {\n      var bar = 1\n      bar = bar\n  }' After the quick-fix is applied: 'fun test() {\n      var bar = 1\n  }'",
+                  "markdown": "Reports assignments of a variable to itself.\n\nThe quick-fix removes the redundant assignment.\n\n**Example:**\n\n\n      fun test() {\n          var bar = 1\n          bar = bar\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun test() {\n          var bar = 1\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RecursiveEqualsCall",
+                "shortDescription": {
+                  "text": "Recursive equals call"
+                },
+                "fullDescription": {
+                  "text": "Reports recursive 'equals'('==') calls. In Kotlin, '==' compares object values by calling 'equals' method under the hood. '===', on the other hand, compares objects by reference. '===' is commonly used in 'equals' method implementation. But '===' may be mistakenly mixed up with '==' leading to infinite recursion. Example: 'class X {\n      override fun equals(other: Any?): Boolean {\n          if (this == other) return true\n          return false\n      }\n  }' After the quick-fix is applied: 'class X {\n      override fun equals(other: Any?): Boolean {\n          if (this === other) return true\n          return false\n      }\n  }'",
+                  "markdown": "Reports recursive `equals`(`==`) calls.\n\n\nIn Kotlin, `==` compares object values by calling `equals` method under the hood.\n`===`, on the other hand, compares objects by reference.\n\n\n`===` is commonly used in `equals` method implementation.\nBut `===` may be mistakenly mixed up with `==` leading to infinite recursion.\n\n**Example:**\n\n\n      class X {\n          override fun equals(other: Any?): Boolean {\n              if (this == other) return true\n              return false\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      class X {\n          override fun equals(other: Any?): Boolean {\n              if (this === other) return true\n              return false\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ExplicitThis",
+                "shortDescription": {
+                  "text": "Redundant explicit 'this'"
+                },
+                "fullDescription": {
+                  "text": "Reports an explicit 'this' when it can be omitted. Example: 'class C {\n      private val i = 1\n      fun f() = this.i\n  }' The quick-fix removes the redundant 'this': 'class C {\n      private val i = 1\n      fun f() = i\n  }'",
+                  "markdown": "Reports an explicit `this` when it can be omitted.\n\n**Example:**\n\n\n      class C {\n          private val i = 1\n          fun f() = this.i\n      }\n\nThe quick-fix removes the redundant `this`:\n\n\n      class C {\n          private val i = 1\n          fun f() = i\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "NullChecksToSafeCall",
+                "shortDescription": {
+                  "text": "Null-checks can be replaced with safe-calls"
+                },
+                "fullDescription": {
+                  "text": "Reports chained null-checks that can be replaced with safe-calls. Example: 'fun test(my: My?) {\n      if (my != null && my.foo() != null) {}\n  }' After the quick-fix is applied: 'fun test(my: My?) {\n      if (my?.foo() != null) {}\n  }'",
+                  "markdown": "Reports chained null-checks that can be replaced with safe-calls.\n\n**Example:**\n\n\n      fun test(my: My?) {\n          if (my != null && my.foo() != null) {}\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun test(my: My?) {\n          if (my?.foo() != null) {}\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UnusedMainParameter",
+                "shortDescription": {
+                  "text": "Main parameter is not necessary"
+                },
+                "fullDescription": {
+                  "text": "Reports 'main' function with an unused single parameter.",
+                  "markdown": "Reports `main` function with an unused single parameter."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "FunctionWithLambdaExpressionBody",
+                "shortDescription": {
+                  "text": "Function with `= { ... }` and inferred return type"
+                },
+                "fullDescription": {
+                  "text": "Reports functions with '= { ... }' and inferred return type. Example: 'fun sum(a: Int, b: Int) = { a + b } // The return type of this function is '() -> Int'.' The quick fix removes braces: 'fun sum(a: Int, b: Int) = a + b'",
+                  "markdown": "Reports functions with `= { ... }` and inferred return type.\n\n**Example:**\n\n\n      fun sum(a: Int, b: Int) = { a + b } // The return type of this function is '() -> Int'.\n\nThe quick fix removes braces:\n\n\n      fun sum(a: Int, b: Int) = a + b\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ArrayInDataClass",
+                "shortDescription": {
+                  "text": "Array property in data class"
+                },
+                "fullDescription": {
+                  "text": "Reports properties with an 'Array' type in a 'data' class without overridden 'equals()' or 'hashCode()'. Array parameters are compared by reference equality, which is likely an unexpected behavior. It is strongly recommended to override 'equals()' and 'hashCode()' in such cases. Example: 'data class Text(val lines: Array<String>)' A quick-fix generates missing 'equals()' and 'hashCode()' implementations: 'data class Text(val lines: Array<String>) {\n      override fun equals(other: Any?): Boolean {\n          if (this === other) return true\n          if (javaClass != other?.javaClass) return false\n\n          other as Text\n\n          if (!lines.contentEquals(other.lines)) return false\n\n          return true\n      }\n\n      override fun hashCode(): Int {\n          return lines.contentHashCode()\n      }\n  }'",
+                  "markdown": "Reports properties with an `Array` type in a `data` class without overridden `equals()` or `hashCode()`.\n\n\nArray parameters are compared by reference equality, which is likely an unexpected behavior.\nIt is strongly recommended to override `equals()` and `hashCode()` in such cases.\n\n**Example:**\n\n\n      data class Text(val lines: Array<String>)\n\nA quick-fix generates missing `equals()` and `hashCode()` implementations:\n\n\n      data class Text(val lines: Array<String>) {\n          override fun equals(other: Any?): Boolean {\n              if (this === other) return true\n              if (javaClass != other?.javaClass) return false\n\n              other as Text\n\n              if (!lines.contentEquals(other.lines)) return false\n\n              return true\n          }\n\n          override fun hashCode(): Int {\n              return lines.contentHashCode()\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ConvertTwoComparisonsToRangeCheck",
+                "shortDescription": {
+                  "text": "Two comparisons should be converted to a range check"
+                },
+                "fullDescription": {
+                  "text": "Reports two consecutive comparisons that can be converted to a range check. Checking against a range makes code simpler by removing test subject duplication. Example: 'fun checkMonth(month: Int): Boolean {\n      return month >= 1 && month <= 12\n  }' A quick-fix replaces the comparison-based check with a range one: 'fun checkMonth(month: Int): Boolean {\n      return month in 1..12\n  }'",
+                  "markdown": "Reports two consecutive comparisons that can be converted to a range check.\n\nChecking against a range makes code simpler by removing test subject duplication.\n\n**Example:**\n\n\n      fun checkMonth(month: Int): Boolean {\n          return month >= 1 && month <= 12\n      }\n\nA quick-fix replaces the comparison-based check with a range one:\n\n\n      fun checkMonth(month: Int): Boolean {\n          return month in 1..12\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "LocalVariableName",
+                "shortDescription": {
+                  "text": "Local variable naming convention"
+                },
+                "fullDescription": {
+                  "text": "Reports local variables that do not follow the naming conventions. You can specify the required pattern in the inspection options. Recommended naming conventions: it has to start with a lowercase letter, use camel case and no underscores. Example: 'fun fibonacciNumber(index: Int): Long = when(index) {\n      0 -> 0\n      else -> {\n          // does not follow naming conventions: contains underscore symbol (`_`)\n          var number_one: Long = 0\n          // does not follow naming conventions: starts with an uppercase letter\n          var NUMBER_TWO: Long = 1\n          // follow naming conventions: starts with a lowercase letter, use camel case and no underscores.\n          var numberThree: Long = number_one + NUMBER_TWO\n\n          for(currentIndex in 2..index) {\n              numberThree = number_one + NUMBER_TWO\n              number_one = NUMBER_TWO\n              NUMBER_TWO = numberThree\n          }\n          numberThree\n      }\n  }'",
+                  "markdown": "Reports local variables that do not follow the naming conventions.\n\nYou can specify the required pattern in the inspection options.\n\n[Recommended naming conventions](https://kotlinlang.org/docs/coding-conventions.html#function-names): it has to start with a lowercase letter, use camel case and no underscores.\n\n**Example:**\n\n\n      fun fibonacciNumber(index: Int): Long = when(index) {\n          0 -> 0\n          else -> {\n              // does not follow naming conventions: contains underscore symbol (`_`)\n              var number_one: Long = 0\n              // does not follow naming conventions: starts with an uppercase letter\n              var NUMBER_TWO: Long = 1\n              // follow naming conventions: starts with a lowercase letter, use camel case and no underscores.\n              var numberThree: Long = number_one + NUMBER_TWO\n\n              for(currentIndex in 2..index) {\n                  numberThree = number_one + NUMBER_TWO\n                  number_one = NUMBER_TWO\n                  NUMBER_TWO = numberThree\n              }\n              numberThree\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Naming conventions",
+                      "index": 47,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveRedundantQualifierName",
+                "shortDescription": {
+                  "text": "Redundant qualifier name"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant qualifiers (or their parts) on class names, functions, and properties. A fully qualified name is an unambiguous identifier that specifies which object, function, or property a call refers to. In the contexts where the name can be shortened, the inspection informs on the opportunity and the associated 'Remove redundant qualifier name' quick-fix allows amending the code. Examples: 'package my.simple.name\n  import kotlin.Int.Companion.MAX_VALUE\n\n  class Foo\n\n  fun main() {\n      val a = my.simple.name.Foo()    // 'Foo' resides in the declared 'my.simple.name' package, qualifier is redundant\n      val b = kotlin.Int.MAX_VALUE    // Can be replaced with 'MAX_VALUE' since it's imported\n      val c = kotlin.Double.MAX_VALUE // Can be replaced with 'Double.MAX_VALUE' since built-in types are imported automatically\n  }' After the quick-fix is applied: 'package my.simple.name\n  import kotlin.Int.Companion.MAX_VALUE\n\n  class Foo\n\n  fun main() {\n      val a = Foo()\n      val b = MAX_VALUE\n      val c = Double.MAX_VALUE\n  }'",
+                  "markdown": "Reports redundant qualifiers (or their parts) on class names, functions, and properties.\n\n\nA fully qualified name is an unambiguous identifier that specifies which object, function, or property a call refers to.\nIn the contexts where the name can be shortened, the inspection informs on the opportunity and the associated\n'Remove redundant qualifier name' quick-fix allows amending the code.\n\n**Examples:**\n\n\n      package my.simple.name\n      import kotlin.Int.Companion.MAX_VALUE\n\n      class Foo\n\n      fun main() {\n          val a = my.simple.name.Foo()    // 'Foo' resides in the declared 'my.simple.name' package, qualifier is redundant\n          val b = kotlin.Int.MAX_VALUE    // Can be replaced with 'MAX_VALUE' since it's imported\n          val c = kotlin.Double.MAX_VALUE // Can be replaced with 'Double.MAX_VALUE' since built-in types are imported automatically\n      }\n\nAfter the quick-fix is applied:\n\n\n      package my.simple.name\n      import kotlin.Int.Companion.MAX_VALUE\n\n      class Foo\n\n      fun main() {\n          val a = Foo()\n          val b = MAX_VALUE\n          val c = Double.MAX_VALUE\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveCurlyBracesFromTemplate",
+                "shortDescription": {
+                  "text": "Redundant curly braces in string template"
+                },
+                "fullDescription": {
+                  "text": "Reports usages of curly braces in string templates around simple identifiers. Use the 'Remove curly braces' quick-fix to remove the redundant braces. Examples: 'fun redundant() {\n     val x = 4\n     val y = \"${x}\" // <== redundant\n  }\n\n  fun correctUsage() {\n      val x = \"x\"\n      val y = \"${x.length}\" // <== Ok\n  }' After the quick-fix is applied: 'fun redundant() {\n     val x = 4\n     val y = \"$x\"\n  }\n\n  fun correctUsage() {\n      val x = \"x\" <== Updated\n      val y = \"${x.length}\"\n  }'",
+                  "markdown": "Reports usages of curly braces in string templates around simple identifiers.\n\nUse the 'Remove curly braces' quick-fix to remove the redundant braces.\n\n**Examples:**\n\n\n      fun redundant() {\n         val x = 4\n         val y = \"${x}\" // <== redundant\n      }\n\n      fun correctUsage() {\n          val x = \"x\"\n          val y = \"${x.length}\" // <== Ok\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun redundant() {\n         val x = 4\n         val y = \"$x\"\n      }\n\n      fun correctUsage() {\n          val x = \"x\" <== Updated\n          val y = \"${x.length}\"\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceSubstringWithIndexingOperation",
+                "shortDescription": {
+                  "text": "'substring' call should be replaced with indexing operator"
+                },
+                "fullDescription": {
+                  "text": "Reports calls like '\"abc\".substring(0, 1)' that can be replaced with '\"abc\"[0]'. Obtaining the element by index makes your code simpler. The quick-fix replaces the 'substring' call with the indexing operator. Example: 'fun foo() {\n      \"abc\".substring(0, 1)\n  }' After the quick-fix is applied: 'fun foo() {\n      \"abc\"[0]\n  }'",
+                  "markdown": "Reports calls like `\"abc\".substring(0, 1)` that can be replaced with `\"abc\"[0]`.\n\nObtaining the element by index makes your code simpler.\n\nThe quick-fix replaces the `substring` call with the indexing operator.\n\n**Example:**\n\n\n      fun foo() {\n          \"abc\".substring(0, 1)\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo() {\n          \"abc\"[0]\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "MoveLambdaOutsideParentheses",
+                "shortDescription": {
+                  "text": "Lambda argument inside parentheses"
+                },
+                "fullDescription": {
+                  "text": "Reports lambda expressions in parentheses which can be moved outside. Example: 'fun square(a: Int, b: (Int) -> Int) {\n  b(a * a)\n}\n\nfun foo() {\n  square(2, { it })\n}' After the quick-fix is applied: 'fun foo() {\n  square(2){ it }\n}'",
+                  "markdown": "Reports lambda expressions in parentheses which can be moved outside.\n\n**Example:**\n\n\n    fun square(a: Int, b: (Int) -> Int) {\n      b(a * a)\n    }\n\n    fun foo() {\n      square(2, { it })\n    }\n\nAfter the quick-fix is applied:\n\n\n    fun foo() {\n      square(2){ it }\n    }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "OverridingDeprecatedMember",
+                "shortDescription": {
+                  "text": "Overriding deprecated member"
+                },
+                "fullDescription": {
+                  "text": "Reports declarations that inherit from deprecated members. Example: 'open class BaseService {\n  @Deprecated(\"obsolete\", replaceWith = ReplaceWith(\"connection\"))\n  open fun connect() {}\n\n  open fun connection() {}\n} \n\nclass SomeService: BaseService() {\n  override fun connect() {\n    super.connect()\n  }\n}'",
+                  "markdown": "Reports declarations that inherit from deprecated members.\n\n**Example:**\n\n\n    open class BaseService {\n      @Deprecated(\"obsolete\", replaceWith = ReplaceWith(\"connection\"))\n      open fun connect() {}\n\n      open fun connection() {}\n    } \n\n    class SomeService: BaseService() {\n      override fun connect() {\n        super.connect()\n      }\n    }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Other problems",
+                      "index": 148,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ProhibitTypeParametersForLocalVariablesMigration",
+                "shortDescription": {
+                  "text": "Local variable with type parameters"
+                },
+                "fullDescription": {
+                  "text": "Reports local variables with type parameters. A type parameter for a local variable doesn't make sense because it can't be specialized. Example: 'fun main() {\n      val <T> x = \"\"\n  }' After the quick-fix is applied: 'fun main() {\n      val x = \"\"\n  }' This inspection only reports if the Kotlin language level of the project or module is 1.4 or higher.",
+                  "markdown": "Reports local variables with type parameters.\n\nA type parameter for a local variable doesn't make sense because it can't be specialized.\n\n**Example:**\n\n\n      fun main() {\n          val <T> x = \"\"\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun main() {\n          val x = \"\"\n      }\n\nThis inspection only reports if the Kotlin language level of the project or module is 1.4 or higher."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "ideaSeverity": "ERROR",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Migration",
+                      "index": 118,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "TestFunctionName",
+                "shortDescription": {
+                  "text": "Test function naming convention"
+                },
+                "fullDescription": {
+                  "text": "Reports test function names that do not follow the recommended naming conventions.",
+                  "markdown": "Reports test function names that do not follow the [recommended naming conventions](https://kotlinlang.org/docs/coding-conventions.html#names-for-test-methods)."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Naming conventions",
+                      "index": 47,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RecursivePropertyAccessor",
+                "shortDescription": {
+                  "text": "Recursive property accessor"
+                },
+                "fullDescription": {
+                  "text": "Reports recursive property accessor calls which can end up with a 'StackOverflowError'. Such calls are usually confused with backing field access. Example: 'var counter: Int = 0\n      set(value) {\n          counter = if (value < 0) 0 else value\n      }' After the quick-fix is applied: 'var counter: Int = 0\n      set(value) {\n          field = if (value < 0) 0 else value\n      }'",
+                  "markdown": "Reports recursive property accessor calls which can end up with a `StackOverflowError`.\nSuch calls are usually confused with backing field access.\n\n**Example:**\n\n\n      var counter: Int = 0\n          set(value) {\n              counter = if (value < 0) 0 else value\n          }\n\nAfter the quick-fix is applied:\n\n\n      var counter: Int = 0\n          set(value) {\n              field = if (value < 0) 0 else value\n          }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantUnitExpression",
+                "shortDescription": {
+                  "text": "Redundant 'Unit'"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant 'Unit' expressions. 'Unit' in Kotlin can be used as the return type of functions that do not return anything meaningful. The 'Unit' type has only one possible value, which is the 'Unit' object. Examples: 'fun redundantA(): Unit {\n      return Unit // redundant, 'Unit' is returned by default and matches the expected return type\n  }\n\n  fun requiredA(condition: Boolean): Any {\n      if (condition) return \"hello\"\n      return Unit // explicit 'Unit' is required since the expected type is 'Any'\n  }\n\n  fun redundantB(condition: Boolean): Any = if (condition) {\n      fun ancillary(): Int = 1\n      println(\"${ancillary()}\")\n      Unit // redundant since the last expression is already of type 'Unit'\n  } else {\n      println(\"else\")\n  }\n\n  fun requiredB(condition: Boolean): Any = if (condition) {\n      1024\n      Unit // required, otherwise '1024' (Int) would be the return value\n  } else {\n      println(\"else\")\n  }'",
+                  "markdown": "Reports redundant `Unit` expressions.\n\n\n`Unit` in Kotlin can be used as the return type of functions that do not return anything meaningful.\nThe `Unit` type has only one possible value, which is the `Unit` object.\n\n**Examples:**\n\n\n      fun redundantA(): Unit {\n          return Unit // redundant, 'Unit' is returned by default and matches the expected return type\n      }\n\n      fun requiredA(condition: Boolean): Any {\n          if (condition) return \"hello\"\n          return Unit // explicit 'Unit' is required since the expected type is 'Any'\n      }\n\n      fun redundantB(condition: Boolean): Any = if (condition) {\n          fun ancillary(): Int = 1\n          println(\"${ancillary()}\")\n          Unit // redundant since the last expression is already of type 'Unit'\n      } else {\n          println(\"else\")\n      }\n\n      fun requiredB(condition: Boolean): Any = if (condition) {\n          1024\n          Unit // required, otherwise '1024' (Int) would be the return value\n      } else {\n          println(\"else\")\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PlatformExtensionReceiverOfInline",
+                "shortDescription": {
+                  "text": "'inline fun' with nullable receiver until Kotlin 1.2"
+                },
+                "fullDescription": {
+                  "text": "Reports potentially unsafe calls of inline functions with flexible nullable (platform type with unknown nullability) extension receivers. Before Kotlin 1.2, calls of 'inline fun' with flexible nullable extension receiver (a platform type with an unknown nullability) did not include nullability checks in bytecode. Since Kotlin 1.2, nullability checks are included into the bytecode (see KT-12899). It's recommended to add an explicit '!!' you want an exception to be thrown, or consider changing the function's receiver type to nullable if it should work without exceptions. Example: 'inline fun String.removePrefix(prefix: String): String {\n      return this.substring(prefix.length)\n  }\n\n  fun main() {\n      // `System.getProperty` returns not denotable `String!` type\n      val property = System.getProperty(\"user.dir\")\n      println(property.removePrefix(\"/home\"))\n  }' After the quick-fix is applied: 'inline fun String.removePrefix(prefix: String): String {\n      return this.substring(prefix.length)\n  }\n\n  fun main() {\n      // `System.getProperty` returns not denotable `String!` type\n      val property = System.getProperty(\"user.dir\")\n      println(property!!.removePrefix(\"/home\"))\n  }' This inspection only reports if the Kotlin language level of the project or module is lower than 1.2.",
+                  "markdown": "Reports potentially unsafe calls of inline functions with flexible nullable (platform type with unknown nullability) extension receivers.\n\n\nBefore Kotlin 1.2, calls of `inline fun` with flexible nullable extension receiver (a platform type with an unknown\nnullability) did not include nullability checks in bytecode. Since Kotlin 1.2, nullability checks are included into the bytecode\n(see [KT-12899](https://youtrack.jetbrains.com/issue/KT-12899)).\n\n\nIt's recommended to add an explicit `!!` you want an exception to be thrown,\nor consider changing the function's receiver type to nullable if it should work without exceptions.\n\n**Example:**\n\n\n      inline fun String.removePrefix(prefix: String): String {\n          return this.substring(prefix.length)\n      }\n\n      fun main() {\n          // `System.getProperty` returns not denotable `String!` type\n          val property = System.getProperty(\"user.dir\")\n          println(property.removePrefix(\"/home\"))\n      }\n\nAfter the quick-fix is applied:\n\n\n      inline fun String.removePrefix(prefix: String): String {\n          return this.substring(prefix.length)\n      }\n\n      fun main() {\n          // `System.getProperty` returns not denotable `String!` type\n          val property = System.getProperty(\"user.dir\")\n          println(property!!.removePrefix(\"/home\"))\n      }\n\nThis inspection only reports if the Kotlin language level of the project or module is lower than 1.2."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Java interop issues",
+                      "index": 54,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SuspiciousEqualsCombination",
+                "shortDescription": {
+                  "text": "Suspicious combination of == and ==="
+                },
+                "fullDescription": {
+                  "text": "Reports '==' and '===' comparisons that are both used on the same variable within a single expression. Due to similarities '==' and '===' could be mixed without notice, and it takes a close look to check that '==' used instead of '===' Example: 'if (type === FIELD || type == METHOD || type == ANNOTATION_METHOD || // Note that \"==\" is used incorrectly\n      type === LAMBDA_EXPRESSION) return'",
+                  "markdown": "Reports `==` and `===` comparisons that are both used on the same variable within a single expression.\n\nDue to similarities `==` and `===` could be mixed without notice, and\nit takes a close look to check that `==` used instead of `===`\n\nExample:\n\n\n      if (type === FIELD || type == METHOD || type == ANNOTATION_METHOD || // Note that \"==\" is used incorrectly\n          type === LAMBDA_EXPRESSION) return\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UnusedDataClassCopyResult",
+                "shortDescription": {
+                  "text": "Unused result of data class copy"
+                },
+                "fullDescription": {
+                  "text": "Reports calls to data class 'copy' function without using its result.",
+                  "markdown": "Reports calls to data class `copy` function without using its result."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantElseInIf",
+                "shortDescription": {
+                  "text": "Redundant 'else' in 'if'"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant 'else' in 'if' with 'return' Example: 'fun foo(arg: Boolean): Int {\n      if (arg) return 0\n      else { // This else is redundant, code in braces could be just shifted left\n          someCode()\n      }\n  }' After the quick-fix is applied: 'fun foo(arg: Boolean): Int {\n      if (arg) return 0\n      someCode()\n  }'",
+                  "markdown": "Reports redundant `else` in `if` with `return`\n\n**Example:**\n\n\n      fun foo(arg: Boolean): Int {\n          if (arg) return 0\n          else { // This else is redundant, code in braces could be just shifted left\n              someCode()\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(arg: Boolean): Int {\n          if (arg) return 0\n          someCode()\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplacePutWithAssignment",
+                "shortDescription": {
+                  "text": "'map.put()' can be converted to assignment"
+                },
+                "fullDescription": {
+                  "text": "Reports 'map.put' function calls that can be replaced with indexing operator ('[]'). Using syntactic sugar makes your code simpler. The quick-fix replaces 'put' call with the assignment. Example: 'fun foo(map: MutableMap<Int, String>) {\n      map.put(42, \"foo\")\n  }' After the quick-fix is applied: 'fun foo(map: MutableMap<Int, String>) {\n      map[42] = \"foo\"\n  }'",
+                  "markdown": "Reports `map.put` function calls that can be replaced with indexing operator (`[]`).\n\nUsing syntactic sugar makes your code simpler.\n\nThe quick-fix replaces `put` call with the assignment.\n\n**Example:**\n\n\n      fun foo(map: MutableMap<Int, String>) {\n          map.put(42, \"foo\")\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(map: MutableMap<Int, String>) {\n          map[42] = \"foo\"\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinDoubleNegation",
+                "shortDescription": {
+                  "text": "Redundant double negation"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant double negations. Example: 'val truth = !!true'",
+                  "markdown": "Reports redundant double negations.\n\n**Example:**\n\n      val truth = !!true\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "FunctionName",
+                "shortDescription": {
+                  "text": "Function naming convention"
+                },
+                "fullDescription": {
+                  "text": "Reports function names that do not follow the recommended naming conventions. Example: 'fun Foo() {}' To fix the problem change the name of the function to match the recommended naming conventions.",
+                  "markdown": "Reports function names that do not follow the recommended naming conventions.\n\n**Example:**\n\n\n      fun Foo() {}\n\nTo fix the problem change the name of the function to match the recommended naming conventions."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Naming conventions",
+                      "index": 47,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "DifferentKotlinMavenVersion",
+                "shortDescription": {
+                  "text": "Maven and IDE plugins versions are different"
+                },
+                "fullDescription": {
+                  "text": "Reports the Maven plugin version of the Kotlin compiler that is different from the one that is used in the IDE plugin. This inconsistency may lead to different error reporting behavior in the IDE and the compiler",
+                  "markdown": "Reports the Maven plugin version of the Kotlin compiler that is different from the one that is used in the IDE plugin.\n\nThis inconsistency may lead to different error reporting behavior in the IDE and the compiler"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantUnitReturnType",
+                "shortDescription": {
+                  "text": "Redundant 'Unit' return type"
+                },
+                "fullDescription": {
+                  "text": "Reports a redundant 'Unit' return type which can be omitted.",
+                  "markdown": "Reports a redundant `Unit` return type which can be omitted."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceRangeToWithUntil",
+                "shortDescription": {
+                  "text": "'rangeTo' or the '..' call should be replaced with 'until'"
+                },
+                "fullDescription": {
+                  "text": "Reports calls to 'rangeTo' or the '..' operator instead of calls to 'until'. Using corresponding functions makes your code simpler. The quick-fix replaces 'rangeTo' or the '..' call with 'until'. Example: 'fun foo(a: Int) {\n      for (i in 0..a - 1) {\n\n      }\n  }' After the quick-fix is applied: 'fun foo(a: Int) {\n      for (i in 0 until a) {\n\n      }\n  }'",
+                  "markdown": "Reports calls to `rangeTo` or the `..` operator instead of calls to `until`.\n\nUsing corresponding functions makes your code simpler.\n\nThe quick-fix replaces `rangeTo` or the `..` call with `until`.\n\n**Example:**\n\n\n      fun foo(a: Int) {\n          for (i in 0..a - 1) {\n\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(a: Int) {\n          for (i in 0 until a) {\n\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UnusedEquals",
+                "shortDescription": {
+                  "text": "Unused equals expression"
+                },
+                "fullDescription": {
+                  "text": "Reports unused 'equals'('==') expressions.",
+                  "markdown": "Reports unused `equals`(`==`) expressions."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UnclearPrecedenceOfBinaryExpression",
+                "shortDescription": {
+                  "text": "Multiple operators with different precedence"
+                },
+                "fullDescription": {
+                  "text": "Reports binary expressions that consist of different operators without parentheses. Such expressions can be less readable due to different precedence rules of operators. Example:   fun foo(b: Boolean?, i: Int?) {\n      val x = b ?: i == null // evaluated as `(b ?: i) == null`\n      val y = i ?: 0 + 1 // evaluated as `i ?: (0 + 1)`\n  }",
+                  "markdown": "Reports binary expressions that consist of different operators without parentheses.\n\nSuch expressions can be less readable due to different [precedence rules](https://kotlinlang.org/docs/reference/grammar.html#expressions) of operators.\n\nExample:\n\n```\n  fun foo(b: Boolean?, i: Int?) {\n      val x = b ?: i == null // evaluated as `(b ?: i) == null`\n      val y = i ?: 0 + 1 // evaluated as `i ?: (0 + 1)`\n  }\n```"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UnusedLambdaExpressionBody",
+                "shortDescription": {
+                  "text": "Unused return value of a function with lambda expression body"
+                },
+                "fullDescription": {
+                  "text": "Reports calls with an unused return value when the called function returns a lambda from an expression body. If there is '=' between function header and body block, code from the function will not be evaluated which can lead to incorrect behavior. Remove = token from function declaration can be used to amend the code automatically. Example: 'fun printHello() = { println(\"Hello\") }\n\n  fun main() {\n      printHello() // This function doesn't print anything\n  }' After the quick-fix is applied: 'fun printHello() { println(\"Hello\") }\n\n  fun main() {\n      printHello()\n  }'",
+                  "markdown": "Reports calls with an unused return value when the called function returns a lambda from an expression body.\n\n\nIf there is `=` between function header and body block,\ncode from the function will not be evaluated which can lead to incorrect behavior.\n\n**Remove = token from function declaration** can be used to amend the code automatically.\n\nExample:\n\n\n      fun printHello() = { println(\"Hello\") }\n\n      fun main() {\n          printHello() // This function doesn't print anything\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun printHello() { println(\"Hello\") }\n\n      fun main() {\n          printHello()\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ConvertLambdaToReference",
+                "shortDescription": {
+                  "text": "Can be replaced with function reference"
+                },
+                "fullDescription": {
+                  "text": "Reports function literal expressions that can be replaced with function references. Replacing lambdas with function references often makes code look more concise and understandable. Example: 'fun Int.isEven() = this % 2 == 0\n\n  fun example() {\n      val numbers = listOf(1, 2, 4, 7, 9, 10)\n      val evenNumbers = numbers.filter { it.isEven() }\n  }' After the quick-fix is applied: 'fun Int.isEven() = this % 2 == 0\n\n  fun example() {\n      val numbers = listOf(1, 2, 4, 7, 9, 10)\n      val evenNumbers = numbers.filter(Int::isEven)\n  }'",
+                  "markdown": "Reports function literal expressions that can be replaced with function references.\n\nReplacing lambdas with function references often makes code look more concise and understandable.\n\n**Example:**\n\n\n      fun Int.isEven() = this % 2 == 0\n\n      fun example() {\n          val numbers = listOf(1, 2, 4, 7, 9, 10)\n          val evenNumbers = numbers.filter { it.isEven() }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun Int.isEven() = this % 2 == 0\n\n      fun example() {\n          val numbers = listOf(1, 2, 4, 7, 9, 10)\n          val evenNumbers = numbers.filter(Int::isEven)\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantSetter",
+                "shortDescription": {
+                  "text": "Redundant property setter"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant property setters. Setter is considered to be redundant in one of the following cases: Setter has no body. Accessor visibility isn't changed, declaration isn't 'external' and has no annotations. 'var myPropWithRedundantSetter: Int = 0\n      set // redundant\n\n  var myPropA: Int = 0\n      private set // OK - property visibility is changed to private\n\n  var myPropB: Int = 0\n      external set // OK - implemented not in Kotlin (external)\n\n  var myPropC: Int = 0\n      @Inject set // OK - accessor is annotated' Setter body is a block with a single statement assigning the parameter to the backing field. 'var prop: Int = 0\n      set(value) { // redundant\n          field = value\n      }'",
+                  "markdown": "Reports redundant property setters.\n\n\nSetter is considered to be redundant in one of the following cases:\n\n1. Setter has no body. Accessor visibility isn't changed, declaration isn't `external` and has no annotations.\n\n\n         var myPropWithRedundantSetter: Int = 0\n             set // redundant\n\n         var myPropA: Int = 0\n             private set // OK - property visibility is changed to private\n\n         var myPropB: Int = 0\n             external set // OK - implemented not in Kotlin (external)\n\n         var myPropC: Int = 0\n             @Inject set // OK - accessor is annotated\n               \n2. Setter body is a block with a single statement assigning the parameter to the backing field.\n\n\n         var prop: Int = 0\n             set(value) { // redundant\n                 field = value\n             }\n              \n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CanSealedSubClassBeObject",
+                "shortDescription": {
+                  "text": "Sealed sub-class without state and overridden equals"
+                },
+                "fullDescription": {
+                  "text": "Reports direct inheritors of 'sealed' classes that have no state and overridden 'equals()' method. It's highly recommended to override 'equals()' to provide comparison stability, or convert the 'class' to an 'object' to reach the same effect. Example: 'sealed class Receiver {\n      class Everyone : Receiver()\n      class User(val id: Int) : Receiver()\n  }' A quick-fix converts a 'class' into an 'object': 'sealed class Receiver {\n      object Everyone : Receiver()\n      class User(val id: Int) : Receiver()\n  }'",
+                  "markdown": "Reports direct inheritors of `sealed` classes that have no state and overridden `equals()` method.\n\nIt's highly recommended to override `equals()` to provide comparison stability, or convert the `class` to an `object` to reach the same effect.\n\n**Example:**\n\n\n      sealed class Receiver {\n          class Everyone : Receiver()\n          class User(val id: Int) : Receiver()\n      }\n\nA quick-fix converts a `class` into an `object`:\n\n\n      sealed class Receiver {\n          object Everyone : Receiver()\n          class User(val id: Int) : Receiver()\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PropertyName",
+                "shortDescription": {
+                  "text": "Property naming convention"
+                },
+                "fullDescription": {
+                  "text": "Reports property names that do not follow the recommended naming conventions. Consistent naming allows for easier code reading and understanding. According to the Kotlin official style guide, property names should start with a lowercase letter and use camel case. It is possible to introduce other naming rules by changing the \"Pattern\" regular expression. Example: 'val My_Cool_Property = \"\"' A quick-fix renames the class according to the Kotlin naming conventions: 'val myCoolProperty = \"\"'",
+                  "markdown": "Reports property names that do not follow the recommended naming conventions.\n\n\nConsistent naming allows for easier code reading and understanding.\nAccording to the [Kotlin official style guide](https://kotlinlang.org/docs/coding-conventions.html#naming-rules),\nproperty names should start with a lowercase letter and use camel case.\n\nIt is possible to introduce other naming rules by changing the \"Pattern\" regular expression.\n\n**Example:**\n\n\n      val My_Cool_Property = \"\"\n\nA quick-fix renames the class according to the Kotlin naming conventions:\n\n\n      val myCoolProperty = \"\"\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Naming conventions",
+                      "index": 47,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinMavenPluginPhase",
+                "shortDescription": {
+                  "text": "Kotlin Maven Plugin misconfigured"
+                },
+                "fullDescription": {
+                  "text": "Reports kotlin-maven-plugin configuration issues",
+                  "markdown": "Reports kotlin-maven-plugin configuration issues"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ConvertToStringTemplate",
+                "shortDescription": {
+                  "text": "String concatenation that can be converted to string template"
+                },
+                "fullDescription": {
+                  "text": "Reports string concatenation that can be converted to a string template. Using string templates is recommended as it makes code easier to read. Example: 'fun example() {\n      val capitals = mapOf(\"France\" to \"Paris\", \"Spain\" to \"Madrid\")\n      for ((country, capital) in capitals) {\n          print(capital + \" is a capital of \" + country)\n      }\n  }' After the quick-fix is applied: 'fun example() {\n      val capitals = mapOf(\"France\" to \"Paris\", \"Spain\" to \"Madrid\")\n      for ((country, capital) in capitals) {\n          print(\"$capital is a capital of $country\")\n      }\n  }'",
+                  "markdown": "Reports string concatenation that can be converted to a string template.\n\nUsing string templates is recommended as it makes code easier to read.\n\n**Example:**\n\n\n      fun example() {\n          val capitals = mapOf(\"France\" to \"Paris\", \"Spain\" to \"Madrid\")\n          for ((country, capital) in capitals) {\n              print(capital + \" is a capital of \" + country)\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun example() {\n          val capitals = mapOf(\"France\" to \"Paris\", \"Spain\" to \"Madrid\")\n          for ((country, capital) in capitals) {\n              print(\"$capital is a capital of $country\")\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SimplifiableCall",
+                "shortDescription": {
+                  "text": "Library function call could be simplified"
+                },
+                "fullDescription": {
+                  "text": "Reports library function calls which could be replaced by simplified one. Using corresponding functions makes your code simpler. The quick-fix replaces the function calls with another one. Example: 'fun test(list: List<Any>) {\n      list.filter { it is String }\n  }' After the quick-fix is applied: 'fun test(list: List<Any>) {\n      list.filterIsInstance<String>()\n  }'",
+                  "markdown": "Reports library function calls which could be replaced by simplified one.\n\nUsing corresponding functions makes your code simpler.\n\nThe quick-fix replaces the function calls with another one.\n\n**Example:**\n\n\n      fun test(list: List<Any>) {\n          list.filter { it is String }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun test(list: List<Any>) {\n          list.filterIsInstance<String>()\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ObjectLiteralToLambda",
+                "shortDescription": {
+                  "text": "Object literal can be converted to lambda"
+                },
+                "fullDescription": {
+                  "text": "Reports anonymous object literals implementing a Java interface with a single abstract method that can be converted into a call with a lambda expression. Example: 'class SomeService {\n  val threadPool = Executors.newCachedThreadPool()\n    \n  fun foo() {\n    threadPool.submit(object : Runnable {\n      override fun run() {\n        println(\"hello\")\n      }\n    })\n  }\n}' After the quick-fix is applied: 'fun foo() {\n    threadPool.submit { println(\"hello\") }\n  }'",
+                  "markdown": "Reports anonymous object literals implementing a Java interface with a single abstract method that can be converted into a call with a lambda expression.\n\n**Example:**\n\n\n    class SomeService {\n      val threadPool = Executors.newCachedThreadPool()\n        \n      fun foo() {\n        threadPool.submit(object : Runnable {\n          override fun run() {\n            println(\"hello\")\n          }\n        })\n      }\n    }\n\nAfter the quick-fix is applied:\n\n\n      fun foo() {\n        threadPool.submit { println(\"hello\") }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantLambdaOrAnonymousFunction",
+                "shortDescription": {
+                  "text": "Redundant creation of lambda or anonymous function"
+                },
+                "fullDescription": {
+                  "text": "Reports lambdas or anonymous functions that are created and used immediately. 'fun test() {\n      ({ println() })() // redundant\n      (fun() { println() })() // redundant\n  }'",
+                  "markdown": "Reports lambdas or anonymous functions that are created and used immediately.\n\n\n      fun test() {\n          ({ println() })() // redundant\n          (fun() { println() })() // redundant\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "BooleanLiteralArgument",
+                "shortDescription": {
+                  "text": "Boolean literal argument without parameter name"
+                },
+                "fullDescription": {
+                  "text": "Reports call arguments with 'Boolean' type without explicit parameter names specified. When multiple boolean literals are passed sequentially, it's easy to forget parameter ordering that could lead to mistakes. Explicit parameter names allow for easier code reading and understanding. Example: 'fun check(checkName: Boolean, checkAddress: Boolean, checkPhone: Boolean) {}\n\n  fun usage() {\n      check(true, false, true) // What does this mean?\n  }' A quick-fix adds missing parameter names: 'fun check(checkName: Boolean, checkAddress: Boolean, checkPhone: Boolean) {}\n\n  fun usage() {\n      check(checkName = true, checkAddress = false, checkPhone = true)\n  }'",
+                  "markdown": "Reports call arguments with `Boolean` type without explicit parameter names specified.\n\n\nWhen multiple boolean literals are passed sequentially, it's easy to forget parameter ordering that could lead to mistakes.\nExplicit parameter names allow for easier code reading and understanding.\n\n**Example:**\n\n\n      fun check(checkName: Boolean, checkAddress: Boolean, checkPhone: Boolean) {}\n\n      fun usage() {\n          check(true, false, true) // What does this mean?\n      }\n\nA quick-fix adds missing parameter names:\n\n\n      fun check(checkName: Boolean, checkAddress: Boolean, checkPhone: Boolean) {}\n\n      fun usage() {\n          check(checkName = true, checkAddress = false, checkPhone = true)\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ConvertArgumentToSet",
+                "shortDescription": {
+                  "text": "Argument could be converted to 'Set' to improve performance"
+                },
+                "fullDescription": {
+                  "text": "Detects the function calls that could work faster with an argument converted to 'Set'. Operations like 'minus' or 'intersect' are more effective when their argument is a set. An explicit conversion of an 'Iterable<T>' or an 'Array<T>' into a 'Set<T>' can often make code more effective. The quick-fix adds an explicit conversion to the function call. Example: 'fun <T> f(a: Iterable<T>, b: Iterable<T>): Int =\n      a.intersect(b).size' After the quick-fix is applied: 'fun <T> f(a: Iterable<T>, b: Iterable<T>): Int =\n      a.intersect(b.toSet()).size'",
+                  "markdown": "Detects the function calls that could work faster with an argument converted to `Set`.\n\n\nOperations like 'minus' or 'intersect' are more effective when their argument is a set.\nAn explicit conversion of an `Iterable<T>` or an `Array<T>`\ninto a `Set<T>` can often make code more effective.\n\n\nThe quick-fix adds an explicit conversion to the function call.\n\n**Example:**\n\n\n      fun <T> f(a: Iterable<T>, b: Iterable<T>): Int =\n          a.intersect(b).size\n\nAfter the quick-fix is applied:\n\n\n      fun <T> f(a: Iterable<T>, b: Iterable<T>): Int =\n          a.intersect(b.toSet()).size\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Other problems",
+                      "index": 148,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceGuardClauseWithFunctionCall",
+                "shortDescription": {
+                  "text": "Guard clause can be replaced with Kotlin's function call"
+                },
+                "fullDescription": {
+                  "text": "Reports guard clauses that can be replaced with a function call. Example: 'fun test(foo: Int?) {\n      if (foo == null) throw IllegalArgumentException(\"foo\") // replaceable clause\n  }' After the quick-fix is applied: 'fun test(foo: Int?) {\n      checkNotNull(foo)\n  }'",
+                  "markdown": "Reports guard clauses that can be replaced with a function call.\n\n**Example:**\n\n      fun test(foo: Int?) {\n          if (foo == null) throw IllegalArgumentException(\"foo\") // replaceable clause\n      }\n\nAfter the quick-fix is applied:\n\n      fun test(foo: Int?) {\n          checkNotNull(foo)\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceToStringWithStringTemplate",
+                "shortDescription": {
+                  "text": "Call of 'toString' could be replaced with string template"
+                },
+                "fullDescription": {
+                  "text": "Reports 'toString' function calls that can be replaced with a string template. Using string templates makes your code simpler. The quick-fix replaces 'toString' with a string template. Example: 'fun test(): String {\n      val x = 1\n      return x.toString()\n  }' After the quick-fix is applied: 'fun test(): String {\n      val x = 1\n      return \"$x\"\n  }'",
+                  "markdown": "Reports `toString` function calls that can be replaced with a string template.\n\nUsing string templates makes your code simpler.\n\nThe quick-fix replaces `toString` with a string template.\n\n**Example:**\n\n\n      fun test(): String {\n          val x = 1\n          return x.toString()\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun test(): String {\n          val x = 1\n          return \"$x\"\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ProtectedInFinal",
+                "shortDescription": {
+                  "text": "'protected' visibility is effectively 'private' in a final class"
+                },
+                "fullDescription": {
+                  "text": "Reports 'protected' visibility used inside of a 'final' class. In such cases 'protected' members are accessible only in the class itself, so they are effectively 'private'. Example: 'class FinalClass {\n      protected fun foo() {}\n  }' After the quick-fix is applied: 'class FinalClass {\n      private fun foo() {}\n  }'",
+                  "markdown": "Reports `protected` visibility used inside of a `final` class. In such cases `protected` members are accessible only in the class itself, so they are effectively `private`.\n\n**Example:**\n\n\n      class FinalClass {\n          protected fun foo() {}\n      }\n\nAfter the quick-fix is applied:\n\n\n      class FinalClass {\n          private fun foo() {}\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceRangeStartEndInclusiveWithFirstLast",
+                "shortDescription": {
+                  "text": "Boxed properties should be replaced with unboxed"
+                },
+                "fullDescription": {
+                  "text": "Reports boxed 'Range.start' and 'Range.endInclusive' properties. These properties can be replaced with unboxed 'first' and 'last' properties to avoid redundant calls. The quick-fix replaces 'start' and 'endInclusive' properties with the corresponding 'first' and 'last'. Example: 'fun foo(range: CharRange) {\n      val lastElement = range.endInclusive\n  }' After the quick-fix is applied: 'fun foo(range: CharRange) {\n      val lastElement = range.last\n  }'",
+                  "markdown": "Reports **boxed** `Range.start` and `Range.endInclusive` properties.\n\nThese properties can be replaced with **unboxed** `first` and `last` properties to avoid redundant calls.\n\nThe quick-fix replaces `start` and `endInclusive` properties with the corresponding `first` and `last`.\n\n**Example:**\n\n\n      fun foo(range: CharRange) {\n          val lastElement = range.endInclusive\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(range: CharRange) {\n          val lastElement = range.last\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceSizeCheckWithIsNotEmpty",
+                "shortDescription": {
+                  "text": "Size check can be replaced with 'isNotEmpty()'"
+                },
+                "fullDescription": {
+                  "text": "Reports size checks of 'Collections/Array/String' that should be replaced with 'isNotEmpty()'. Using 'isNotEmpty()' makes your code simpler. The quick-fix replaces the size check with 'isNotEmpty()'. Example: 'fun foo() {\n      val arrayOf = arrayOf(1, 2, 3)\n      arrayOf.size > 0\n  }' After the quick-fix is applied: 'fun foo() {\n      val arrayOf = arrayOf(1, 2, 3)\n      arrayOf.isNotEmpty()\n  }'",
+                  "markdown": "Reports size checks of `Collections/Array/String` that should be replaced with `isNotEmpty()`.\n\nUsing `isNotEmpty()` makes your code simpler.\n\nThe quick-fix replaces the size check with `isNotEmpty()`.\n\n**Example:**\n\n\n      fun foo() {\n          val arrayOf = arrayOf(1, 2, 3)\n          arrayOf.size > 0\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo() {\n          val arrayOf = arrayOf(1, 2, 3)\n          arrayOf.isNotEmpty()\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantSemicolon",
+                "shortDescription": {
+                  "text": "Redundant semicolon"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant semicolons (';') that can be safely removed. Kotlin does not require a semicolon at the end of each statement or expression. A quick-fix is suggested to remove redundant semicolons. Example: 'val myMap = mapOf(\"one\" to 1, \"two\" to 2);\n  myMap.forEach { (key, value) ->  print(\"$key -> $value\")};' After the quick-fix is applied: 'val myMap = mapOf(\"one\" to 1, \"two\" to 2)\n  myMap.forEach { (key, value) ->  print(\"$key -> $value\")}' There are two cases though where a semicolon is required: Several statements placed on a single line need to be separated with semicolons: 'map.forEach { val (key, value) = it; println(\"$key -> $value\") }' 'enum' classes that also declare properties or functions, require a semicolon after the list of enum constants: 'enum class Mode {\n      SILENT, VERBOSE;\n\n      fun isSilent(): Boolean = this == SILENT\n  }'",
+                  "markdown": "Reports redundant semicolons (`;`) that can be safely removed.\n\n\nKotlin does not require a semicolon at the end of each statement or expression.\nA quick-fix is suggested to remove redundant semicolons.\n\n**Example:**\n\n\n      val myMap = mapOf(\"one\" to 1, \"two\" to 2);\n      myMap.forEach { (key, value) ->  print(\"$key -> $value\")};\n\nAfter the quick-fix is applied:\n\n\n      val myMap = mapOf(\"one\" to 1, \"two\" to 2)\n      myMap.forEach { (key, value) ->  print(\"$key -> $value\")}\n\nThere are two cases though where a semicolon is required:\n\n1. Several statements placed on a single line need to be separated with semicolons:\n\n\n         map.forEach { val (key, value) = it; println(\"$key -> $value\") }\n\n2. `enum` classes that also declare properties or functions, require a semicolon after the list of enum constants:\n\n\n         enum class Mode {\n             SILENT, VERBOSE;\n\n             fun isSilent(): Boolean = this == SILENT\n         }\n               \n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "IntroduceWhenSubject",
+                "shortDescription": {
+                  "text": "'when' that can be simplified by introducing an argument"
+                },
+                "fullDescription": {
+                  "text": "Reports a 'when' expression that can be simplified by introducing a subject argument. Example: 'fun test(obj: Any): String {\n      return when {\n          obj is String -> \"string\"\n          obj is Int -> \"int\"\n          else -> \"unknown\"\n      }\n  }' The quick fix introduces a subject argument: 'fun test(obj: Any): String {\n      return when (obj) {\n          is String -> \"string\"\n          is Int -> \"int\"\n          else -> \"unknown\"\n      }\n  }'",
+                  "markdown": "Reports a `when` expression that can be simplified by introducing a subject argument.\n\n**Example:**\n\n\n      fun test(obj: Any): String {\n          return when {\n              obj is String -> \"string\"\n              obj is Int -> \"int\"\n              else -> \"unknown\"\n          }\n      }\n\nThe quick fix introduces a subject argument:\n\n\n      fun test(obj: Any): String {\n          return when (obj) {\n              is String -> \"string\"\n              is Int -> \"int\"\n              else -> \"unknown\"\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "DeprecatedCallableAddReplaceWith",
+                "shortDescription": {
+                  "text": "@Deprecated annotation without 'replaceWith' argument"
+                },
+                "fullDescription": {
+                  "text": "Reports deprecated functions and properties that do not have the 'kotlin.ReplaceWith' argument in its 'kotlin.deprecated' annotation and suggests to add one based on their body. Kotlin provides the 'ReplaceWith' argument to replace deprecated declarations automatically. It is recommended to use the argument to fix deprecation issues in code. Example: '@Deprecated(\"Use refined() instead.\")\n  fun deprecated() = refined()\n\n  fun refined() = 42' A quick-fix adds the 'ReplaceWith()' argument: '@Deprecated(\"Use refined() instead.\", ReplaceWith(\"refined()\"))\n  fun deprecated() = refined()\n\n  fun refined() = 42'",
+                  "markdown": "Reports deprecated functions and properties that do not have the `kotlin.ReplaceWith` argument in its `kotlin.deprecated` annotation and suggests to add one based on their body.\n\n\nKotlin provides the `ReplaceWith` argument to replace deprecated declarations automatically.\nIt is recommended to use the argument to fix deprecation issues in code.\n\n**Example:**\n\n\n      @Deprecated(\"Use refined() instead.\")\n      fun deprecated() = refined()\n\n      fun refined() = 42\n\nA quick-fix adds the `ReplaceWith()` argument:\n\n\n      @Deprecated(\"Use refined() instead.\", ReplaceWith(\"refined()\"))\n      fun deprecated() = refined()\n\n      fun refined() = 42\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Other problems",
+                      "index": 148,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ComplexRedundantLet",
+                "shortDescription": {
+                  "text": "Redundant argument-based `let` call"
+                },
+                "fullDescription": {
+                  "text": "Reports a redundant argument-based 'let' call. 'let' is redundant when the lambda parameter is only used as a qualifier in a call expression. If you need to give a name to the qualifying expression, declare a local variable. Example: 'fun splitNumbers() {\n      \"1,2,3\".let { it.split(',') }\n  }' A quick-fix removes the extra 'let()' call: 'fun example() {\n      \"1,2,3\".split(',')\n  }' Alternative: 'fun splitNumbers() {\n      val numbers = \"1,2,3\"\n      numbers.split(',')\n  }'",
+                  "markdown": "Reports a redundant argument-based `let` call.\n\n`let` is redundant when the lambda parameter is only used as a qualifier in a call expression.\n\nIf you need to give a name to the qualifying expression, declare a local variable.\n\n**Example:**\n\n\n      fun splitNumbers() {\n          \"1,2,3\".let { it.split(',') }\n      }\n\nA quick-fix removes the extra `let()` call:\n\n\n      fun example() {\n          \"1,2,3\".split(',')\n      }\n\nAlternative:\n\n\n      fun splitNumbers() {\n          val numbers = \"1,2,3\"\n          numbers.split(',')\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveRedundantSpreadOperator",
+                "shortDescription": {
+                  "text": "Redundant spread operator"
+                },
+                "fullDescription": {
+                  "text": "Reports the use of a redundant spread operator for a family of 'arrayOf' function calls. Use the 'Remove redundant spread operator' quick-fix to clean up the code. Examples: 'fun foo(vararg s: String) { }\n\n  fun bar(ss: Array<String>) {\n      foo(*arrayOf(\"abc\"))       // for the both calls of 'foo', array creation\n      foo(*arrayOf(*ss, \"zzz\"))  // and its subsequent \"spreading\" is redundant\n  }' After the quick-fix is applied: 'fun foo(vararg s: String) { }\n\n  fun bar(ss: Array<String>) {\n      foo(\"abc\")\n      foo(*ss, \"zzz\")\n  }'",
+                  "markdown": "Reports the use of a redundant spread operator for a family of `arrayOf` function calls.\n\nUse the 'Remove redundant spread operator' quick-fix to clean up the code.\n\n**Examples:**\n\n\n      fun foo(vararg s: String) { }\n\n      fun bar(ss: Array<String>) {\n          foo(*arrayOf(\"abc\"))       // for the both calls of 'foo', array creation\n          foo(*arrayOf(*ss, \"zzz\"))  // and its subsequent \"spreading\" is redundant\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(vararg s: String) { }\n\n      fun bar(ss: Array<String>) {\n          foo(\"abc\")\n          foo(*ss, \"zzz\")\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ProhibitJvmOverloadsOnConstructorsOfAnnotationClassesMigration",
+                "shortDescription": {
+                  "text": "'@JvmOverloads' annotation cannot be used on constructors of annotation classes since 1.4"
+                },
+                "fullDescription": {
+                  "text": "Reports '@JvmOverloads' on constructors of annotation classes because it's meaningless. There is no footprint of '@JvmOverloads' in the generated bytecode and Kotlin metadata, so '@JvmOverloads' doesn't affect the generated bytecode and the code behavior. '@JvmOverloads' on constructors of annotation classes causes a compilation error since Kotlin 1.4. Example: 'annotation class A @JvmOverloads constructor(val x: Int = 1)' After the quick-fix is applied: 'annotation class A constructor(val x: Int = 1)'",
+                  "markdown": "Reports `@JvmOverloads` on constructors of annotation classes because it's meaningless.\n\n\nThere is no footprint of `@JvmOverloads` in the generated bytecode and Kotlin metadata,\nso `@JvmOverloads` doesn't affect the generated bytecode and the code behavior.\n\n`@JvmOverloads` on constructors of annotation classes causes a compilation error since Kotlin 1.4.\n\n**Example:**\n\n\n      annotation class A @JvmOverloads constructor(val x: Int = 1)\n\nAfter the quick-fix is applied:\n\n\n      annotation class A constructor(val x: Int = 1)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "ideaSeverity": "ERROR",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Migration",
+                      "index": 118,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveSetterParameterType",
+                "shortDescription": {
+                  "text": "Redundant setter parameter type"
+                },
+                "fullDescription": {
+                  "text": "Reports explicitly specified parameter types in property setters. Setter parameter type always matches the property type, so it's not required to be explicit. The 'Remove explicit type specification' quick-fix allows amending the code accordingly. Examples: 'fun process(x: Int) {}\n\n  var x: Int = 0\n      set(value: Int) = process(value) // <== 'Int' specification can be safely omitted' After the quick-fix is applied: 'fun process(x: Int) {}\n\n  var x: Int = 0\n      set(value) = process(value)'",
+                  "markdown": "Reports explicitly specified parameter types in property setters.\n\n\nSetter parameter type always matches the property type, so it's not required to be explicit.\nThe 'Remove explicit type specification' quick-fix allows amending the code accordingly.\n\n**Examples:**\n\n\n      fun process(x: Int) {}\n\n      var x: Int = 0\n          set(value: Int) = process(value) // <== 'Int' specification can be safely omitted\n\nAfter the quick-fix is applied:\n\n\n      fun process(x: Int) {}\n\n      var x: Int = 0\n          set(value) = process(value)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "IfThenToElvis",
+                "shortDescription": {
+                  "text": "If-Then foldable to '?:'"
+                },
+                "fullDescription": {
+                  "text": "Reports 'if-then' expressions that can be folded into elvis ('?:') expressions. Example: 'fun maybeFoo(): String? = \"foo\"\n\n  var foo = maybeFoo()\n  val bar = if (foo == null) \"hello\" else foo' The quick fix converts the 'if-then' expression into an elvis ('?:') expression: 'fun maybeFoo(): String? = \"foo\"\n\n  var foo = maybeFoo()\n  val bar = foo ?: \"hello\"'",
+                  "markdown": "Reports `if-then` expressions that can be folded into elvis (`?:`) expressions.\n\n**Example:**\n\n\n      fun maybeFoo(): String? = \"foo\"\n\n      var foo = maybeFoo()\n      val bar = if (foo == null) \"hello\" else foo\n\nThe quick fix converts the `if-then` expression into an elvis (`?:`) expression:\n\n\n      fun maybeFoo(): String? = \"foo\"\n\n      var foo = maybeFoo()\n      val bar = foo ?: \"hello\"\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "WrapUnaryOperator",
+                "shortDescription": {
+                  "text": "Ambiguous unary operator use with number constant"
+                },
+                "fullDescription": {
+                  "text": "Reports an unary operator followed by a dot qualifier such as '-1.inc()'. Code like '-1.inc()' can be misleading because '-' has a lower precedence than '.inc()'. As a result, '-1.inc()' evaluates to '-2' and not '0' as it might be expected. Wrap unary operator and value with () quick-fix can be used to amend the code automatically.",
+                  "markdown": "Reports an unary operator followed by a dot qualifier such as `-1.inc()`.\n\nCode like `-1.inc()` can be misleading because `-` has a lower precedence than `.inc()`.\nAs a result, `-1.inc()` evaluates to `-2` and not `0` as it might be expected.\n\n**Wrap unary operator and value with ()** quick-fix can be used to amend the code automatically."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ConflictingExtensionProperty",
+                "shortDescription": {
+                  "text": "Extension property conflicting with synthetic one"
+                },
+                "fullDescription": {
+                  "text": "Reports extension properties that conflict with synthetic ones that have been automatically produced from Java 'get' or 'set' methods. Such properties should be either removed or renamed to avoid breaking code by future changes in the compiler. A quick-fix deletes an extention property. Example: 'val File.name: String\n      get() = getName()' A quick-fix adds the '@Deprecated' annotation: '@Deprecated(\"Is replaced with automatic synthetic extension\", ReplaceWith(\"name\"), level = DeprecationLevel.HIDDEN)\n  val File.name: String\n      get() = getName()'",
+                  "markdown": "Reports extension properties that conflict with synthetic ones that have been automatically produced from Java `get` or `set` methods.\n\nSuch properties should be either removed or renamed to avoid breaking code by future changes in the compiler.\n\nA quick-fix deletes an extention property.\n\n**Example:**\n\n\n      val File.name: String\n          get() = getName()\n\nA quick-fix adds the `@Deprecated` annotation:\n\n\n      @Deprecated(\"Is replaced with automatic synthetic extension\", ReplaceWith(\"name\"), level = DeprecationLevel.HIDDEN)\n      val File.name: String\n          get() = getName()\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceJavaStaticMethodWithKotlinAnalog",
+                "shortDescription": {
+                  "text": "Java methods should be replaced with Kotlin analog"
+                },
+                "fullDescription": {
+                  "text": "Reports a Java method call that can be replaced with a Kotlin function, for example, 'System.out.println()'. Replacing the code gets rid of the dependency to Java and makes the idiomatic Kotlin code. The quick-fix replaces the Java method calls on the same Kotlin call. Example: 'import java.util.Arrays\n\n  fun main() {\n      val a = Arrays.asList(1, 3, null)\n  }' After the quick-fix is applied: 'fun main() {\n      val a = listOf(1, 3, null)\n  }'",
+                  "markdown": "Reports a Java method call that can be replaced with a Kotlin function, for example, `System.out.println()`.\n\nReplacing the code gets rid of the dependency to Java and makes the idiomatic Kotlin code.\n\nThe quick-fix replaces the Java method calls on the same Kotlin call.\n\n**Example:**\n\n\n      import java.util.Arrays\n\n      fun main() {\n          val a = Arrays.asList(1, 3, null)\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun main() {\n          val a = listOf(1, 3, null)\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveEmptyParenthesesFromLambdaCall",
+                "shortDescription": {
+                  "text": "Remove unnecessary parentheses from function call with lambda"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant empty parentheses of function calls where the only parameter is a lambda that's outside the parentheses. Use the 'Remove unnecessary parentheses from function call with lambda' quick-fix to clean up the code. Examples: 'fun foo() {\n      listOf(1).forEach() {  }\n  }' After the quick-fix is applied: 'fun foo() {\n      listOf(1).forEach {  }\n  }'",
+                  "markdown": "Reports redundant empty parentheses of function calls where the only parameter is a lambda that's outside the parentheses.\n\nUse the 'Remove unnecessary parentheses from function call with lambda' quick-fix to clean up the code.\n\n**Examples:**\n\n\n      fun foo() {\n          listOf(1).forEach() {  }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo() {\n          listOf(1).forEach {  }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveExplicitSuperQualifier",
+                "shortDescription": {
+                  "text": "Unnecessary supertype qualification"
+                },
+                "fullDescription": {
+                  "text": "Reports 'super' member calls with redundant supertype qualification. Code in a derived class can call its superclass functions and property accessors implementations using the 'super' keyword. To specify the supertype from which the inherited implementation is taken, 'super' can be qualified by the supertype name in angle brackets, e.g. 'super<Base>'. Sometimes this qualification is redundant and can be omitted. Use the 'Remove explicit supertype qualification' quick-fix to clean up the code. Examples: 'open class B {\n      open fun foo(){}\n  }\n\n  class A : B() {\n      override fun foo() {\n         super<B>.foo() // <== redundant because 'B' is the only supertype\n      }\n  }\n\n  interface I {\n      fun foo() {}\n  }\n\n  class C : B(), I {\n      override fun foo() {\n          super<B>.foo() // <== here <B> qualifier is needed to distinguish 'B.foo()' from 'I.foo()'\n      }\n  }' After the quick-fix is applied: 'open class B {\n      open fun foo(){}\n  }\n\n  class A : B() {\n      override fun foo() {\n         super.foo() // <== Updated\n      }\n  }\n\n  interface I {\n      fun foo() {}\n  }\n\n  class C : B(), I {\n      override fun foo() {\n          super<B>.foo()\n      }\n  }'",
+                  "markdown": "Reports `super` member calls with redundant supertype qualification.\n\n\nCode in a derived class can call its superclass functions and property accessors implementations using the `super` keyword.\nTo specify the supertype from which the inherited implementation is taken, `super` can be qualified by the supertype name in\nangle brackets, e.g. `super<Base>`. Sometimes this qualification is redundant and can be omitted.\nUse the 'Remove explicit supertype qualification' quick-fix to clean up the code.\n\n**Examples:**\n\n\n      open class B {\n          open fun foo(){}\n      }\n\n      class A : B() {\n          override fun foo() {\n             super<B>.foo() // <== redundant because 'B' is the only supertype\n          }\n      }\n\n      interface I {\n          fun foo() {}\n      }\n\n      class C : B(), I {\n          override fun foo() {\n              super<B>.foo() // <== here <B> qualifier is needed to distinguish 'B.foo()' from 'I.foo()'\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      open class B {\n          open fun foo(){}\n      }\n\n      class A : B() {\n          override fun foo() {\n             super.foo() // <== Updated\n          }\n      }\n\n      interface I {\n          fun foo() {}\n      }\n\n      class C : B(), I {\n          override fun foo() {\n              super<B>.foo()\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantExplicitType",
+                "shortDescription": {
+                  "text": "Obvious explicit type"
+                },
+                "fullDescription": {
+                  "text": "Reports local variables' explicitly given types which are obvious and thus redundant, like 'val f: Foo = Foo()'. Example: 'class Point(val x: Int, val y: Int)\n\n  fun foo() {\n      val t: Boolean = true\n      val p: Point = Point(1, 2)\n      val i: Int = 42\n  }' After the quick-fix is applied: 'class Point(val x: Int, val y: Int)\n\n  fun foo() {\n      val t = true\n      val p = Point(1, 2)\n      val i = 42\n  }'",
+                  "markdown": "Reports local variables' explicitly given types which are obvious and thus redundant, like `val f: Foo = Foo()`.\n\n**Example:**\n\n\n      class Point(val x: Int, val y: Int)\n\n      fun foo() {\n          val t: Boolean = true\n          val p: Point = Point(1, 2)\n          val i: Int = 42\n      }\n\nAfter the quick-fix is applied:\n\n\n      class Point(val x: Int, val y: Int)\n\n      fun foo() {\n          val t = true\n          val p = Point(1, 2)\n          val i = 42\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SuspiciousVarProperty",
+                "shortDescription": {
+                  "text": "Suspicious 'var' property: its setter does not influence its getter result"
+                },
+                "fullDescription": {
+                  "text": "Reports 'var' properties with default setter and getter that do not reference backing field. Such properties do not affect calling its setter; therefore, it will be clearer to change such property to 'val' and delete the initializer. Change to val and delete initializer quick-fix can be used to amend the code automatically. Example: '// This property always returns '1' and it doesn't important that the property is a 'var'\n  var foo: Int = 0\n      get() = 1'",
+                  "markdown": "Reports `var` properties with default setter and getter that do not reference backing field.\n\n\nSuch properties do not affect calling its setter; therefore, it will be clearer to change such property to `val` and delete the initializer.\n\n**Change to val and delete initializer** quick-fix can be used to amend the code automatically.\n\nExample:\n\n\n      // This property always returns '1' and it doesn't important that the property is a 'var'\n      var foo: Int = 0\n          get() = 1\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "JavaCollectionsStaticMethod",
+                "shortDescription": {
+                  "text": "Java Collections static method call can be replaced with Kotlin stdlib"
+                },
+                "fullDescription": {
+                  "text": "Reports a Java 'Collections' static method call that can be replaced with Kotlin stdlib. Example: 'import java.util.Collections\n\n  fun test() {\n      val mutableList = mutableListOf(1, 2)\n      Collections.fill(mutableList, 3)\n  }' The quick fix replaces Java 'Collections' static method call with the corresponding Kotlin stdlib method call: 'import java.util.Collections\n\n  fun test() {\n      val mutableList = mutableListOf(1, 2)\n      mutableList.fill(3)\n  }'",
+                  "markdown": "Reports a Java `Collections` static method call that can be replaced with Kotlin stdlib.\n\n**Example:**\n\n\n      import java.util.Collections\n\n      fun test() {\n          val mutableList = mutableListOf(1, 2)\n          Collections.fill(mutableList, 3)\n      }\n\nThe quick fix replaces Java `Collections` static method call with the corresponding Kotlin stdlib method call:\n\n\n      import java.util.Collections\n\n      fun test() {\n          val mutableList = mutableListOf(1, 2)\n          mutableList.fill(3)\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantAsync",
+                "shortDescription": {
+                  "text": "Redundant 'async' call"
+                },
+                "fullDescription": {
+                  "text": "Reports 'async' calls that are immediately followed by 'await'. Such calls can be replaced with blocking calls. Example: 'suspend fun test(ctx: CoroutineContext, scope: CoroutineScope) {\n      scope.async(ctx) { doSomeJob() }.await()\n  }' After the quick-fix is applied: 'suspend fun test(ctx: CoroutineContext, scope: CoroutineScope) {\n      withContext(scope.coroutineContext + ctx) { doSomeJob() }\n  }'",
+                  "markdown": "Reports `async` calls that are immediately followed by `await`.\nSuch calls can be replaced with blocking calls.\n\n**Example:**\n\n\n      suspend fun test(ctx: CoroutineContext, scope: CoroutineScope) {\n          scope.async(ctx) { doSomeJob() }.await()\n      }\n\nAfter the quick-fix is applied:\n\n\n      suspend fun test(ctx: CoroutineContext, scope: CoroutineScope) {\n          withContext(scope.coroutineContext + ctx) { doSomeJob() }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "MoveVariableDeclarationIntoWhen",
+                "shortDescription": {
+                  "text": "Variable declaration could be moved inside `when`"
+                },
+                "fullDescription": {
+                  "text": "Reports variable declarations that can be moved inside a 'when' expression. Example: 'fun someCalc(x: Int) = x * 42\n\nfun foo(x: Int): Int {\n  val a = someCalc(x)\n  return when (a) {\n    1 -> a\n    2 -> 2 * a\n    else -> 24\n  }\n}' After the quick-fix is applied: 'fun foo(x: Int): Int {\n  return when (val a = someCalc(x)) {\n    1 -> a\n    2 -> 2 * a\n    else -> 24\n  }\n}'",
+                  "markdown": "Reports variable declarations that can be moved inside a `when` expression.\n\n**Example:**\n\n\n    fun someCalc(x: Int) = x * 42\n\n    fun foo(x: Int): Int {\n      val a = someCalc(x)\n      return when (a) {\n        1 -> a\n        2 -> 2 * a\n        else -> 24\n      }\n    }\n\nAfter the quick-fix is applied:\n\n\n    fun foo(x: Int): Int {\n      return when (val a = someCalc(x)) {\n        1 -> a\n        2 -> 2 * a\n        else -> 24\n      }\n    }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "DeferredIsResult",
+                "shortDescription": {
+                  "text": "Function returning Deferred directly"
+                },
+                "fullDescription": {
+                  "text": "Reports functions with the 'kotlinx.coroutines.Deferred' return type. Functions that use 'Deferred' as return type should have a name with the 'Async' suffix. Otherwise, it's recommended to mark a function as 'suspend' and unwrap 'Deferred' inside it. Example: 'fun calcEverything(): Deferred<Int> {\n      return CompletableDeferred(42)\n  }' After the quick-fix that adds the 'Async' suffix applied: 'fun calcEverythingAsync(): Deferred<Int> {\n      return CompletableDeferred(42)\n  }' After the quick-fix that converts the function into a 'suspend' one applied: 'suspend fun calcEverything(): Int {\n      return CompletableDeferred(42).await()\n  }'",
+                  "markdown": "Reports functions with the `kotlinx.coroutines.Deferred` return type.\n\n\nFunctions that use `Deferred` as return type should have a name with the `Async` suffix.\nOtherwise, it's recommended to mark a function as `suspend` and unwrap `Deferred` inside it.\n\n**Example:**\n\n\n      fun calcEverything(): Deferred<Int> {\n          return CompletableDeferred(42)\n      }\n\nAfter the quick-fix that adds the `Async` suffix applied:\n\n\n      fun calcEverythingAsync(): Deferred<Int> {\n          return CompletableDeferred(42)\n      }\n\nAfter the quick-fix that converts the function into a `suspend` one applied:\n\n\n      suspend fun calcEverything(): Int {\n          return CompletableDeferred(42).await()\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveEmptyParenthesesFromAnnotationEntry",
+                "shortDescription": {
+                  "text": "Remove unnecessary parentheses"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant empty parentheses in annotation entries. Use the 'Remove unnecessary parentheses' quick-fix to clean up the code. Examples: 'annotation class MyAnnotationA\n  annotation class MyAnnotationB(val x: Int)\n  annotation class MyAnnotationC(val x: Int = 10) // default value is present\n\n  @MyAnnotationA() // <== parentheses are redundant\n  fun testA() {\n  }\n\n  @MyAnnotationB() // <== missing argument, parentheses are required\n  fun testB() {\n  }\n\n  @MyAnnotationC() // <== parentheses are redundant\n  fun testC() {\n  }'",
+                  "markdown": "Reports redundant empty parentheses in annotation entries.\n\nUse the 'Remove unnecessary parentheses' quick-fix to clean up the code.\n\n**Examples:**\n\n\n      annotation class MyAnnotationA\n      annotation class MyAnnotationB(val x: Int)\n      annotation class MyAnnotationC(val x: Int = 10) // default value is present\n\n      @MyAnnotationA() // <== parentheses are redundant\n      fun testA() {\n      }\n\n      @MyAnnotationB() // <== missing argument, parentheses are required\n      fun testB() {\n      }\n\n      @MyAnnotationC() // <== parentheses are redundant\n      fun testC() {\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SimplifiableCallChain",
+                "shortDescription": {
+                  "text": "Call chain on collection type can be simplified"
+                },
+                "fullDescription": {
+                  "text": "Reports two-call chains replaceable by a single call. It can help you to avoid redundant code execution. The quick-fix replaces the call chain with a single call. Example: 'fun main() {\n      listOf(1, 2, 3).filter { it > 1 }.count()\n  }' After the quick-fix is applied: 'fun main() {\n      listOf(1, 2, 3).count { it > 1 }\n  }'",
+                  "markdown": "Reports two-call chains replaceable by a single call.\n\nIt can help you to avoid redundant code execution.\n\nThe quick-fix replaces the call chain with a single call.\n\n**Example:**\n\n\n      fun main() {\n          listOf(1, 2, 3).filter { it > 1 }.count()\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun main() {\n          listOf(1, 2, 3).count { it > 1 }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceCallWithBinaryOperator",
+                "shortDescription": {
+                  "text": "Can be replaced with binary operator"
+                },
+                "fullDescription": {
+                  "text": "Reports function calls that can be replaced with binary operators, in particular comparison-related ones. Example: 'fun test(): Boolean {\n      return 2.compareTo(1) > 0 // replaceable 'compareTo()'\n  }' After the quick-fix is applied: 'fun test(): Boolean {\n      return 2 > 1\n  }'",
+                  "markdown": "Reports function calls that can be replaced with binary operators, in particular comparison-related ones.\n\n**Example:**\n\n      fun test(): Boolean {\n          return 2.compareTo(1) > 0 // replaceable 'compareTo()'\n      }\n\nAfter the quick-fix is applied:\n\n      fun test(): Boolean {\n          return 2 > 1\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UnusedUnaryOperator",
+                "shortDescription": {
+                  "text": "Unused unary operator"
+                },
+                "fullDescription": {
+                  "text": "Reports unary operators for number types on unused expressions. Unary operators break previous expression if they are used without braces. As a result, mathematical expressions spanning multi lines can be misleading. Example: 'fun main() {\n      val result = 1 + 2 * 3\n                  + 3              // <== note that '+ 3' doesn't belong to the 'result' variable, it is unused\n      println(\"Result = $result\")  // The result is '7' and not '10' as it might be expected\n  }'",
+                  "markdown": "Reports unary operators for number types on unused expressions.\n\nUnary operators break previous expression if they are used without braces.\nAs a result, mathematical expressions spanning multi lines can be misleading.\n\nExample:\n\n\n      fun main() {\n          val result = 1 + 2 * 3\n                      + 3              // <== note that '+ 3' doesn't belong to the 'result' variable, it is unused\n          println(\"Result = $result\")  // The result is '7' and not '10' as it might be expected\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ClassName",
+                "shortDescription": {
+                  "text": "Class naming convention"
+                },
+                "fullDescription": {
+                  "text": "Reports class names that do not follow the recommended naming conventions. Consistent naming allows for easier code reading and understanding. According to the Kotlin official style guide, class names should start with an uppercase letter and use camel case. It is possible to introduce other naming rules by changing the \"Pattern\" regular expression. Example: 'class user(val name: String)' A quick-fix renames the class according to the Kotlin naming conventions: 'class User(val name: String)'",
+                  "markdown": "Reports class names that do not follow the recommended naming conventions.\n\n\nConsistent naming allows for easier code reading and understanding.\nAccording to the [Kotlin official style guide](https://kotlinlang.org/docs/coding-conventions.html#naming-rules),\nclass names should start with an uppercase letter and use camel case.\n\nIt is possible to introduce other naming rules by changing the \"Pattern\" regular expression.\n\n**Example:**\n\n\n      class user(val name: String)\n\nA quick-fix renames the class according to the Kotlin naming conventions:\n\n\n      class User(val name: String)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Naming conventions",
+                      "index": 47,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveEmptyPrimaryConstructor",
+                "shortDescription": {
+                  "text": "Redundant empty primary constructor"
+                },
+                "fullDescription": {
+                  "text": "Reports empty primary constructors when they are implicitly available anyway. A primary constructor is redundant and can be safely omitted when it does not have any annotations or visibility modifiers. Use the 'Remove empty primary constructor' quick-fix to clean up the code. Examples: 'class MyClassA constructor() //  redundant, can be replaced with 'class MyClassA'\n\n  annotation class MyAnnotation\n  class MyClassB @MyAnnotation constructor() //  required because of annotation\n\n  class MyClassC private constructor() // required because of visibility modifier'",
+                  "markdown": "Reports empty primary constructors when they are implicitly available anyway.\n\n\nA primary constructor is redundant and can be safely omitted when it does not have any annotations or visibility modifiers.\nUse the 'Remove empty primary constructor' quick-fix to clean up the code.\n\n**Examples:**\n\n\n      class MyClassA constructor() //  redundant, can be replaced with 'class MyClassA'\n\n      annotation class MyAnnotation\n      class MyClassB @MyAnnotation constructor() //  required because of annotation\n\n      class MyClassC private constructor() // required because of visibility modifier\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveEmptySecondaryConstructorBody",
+                "shortDescription": {
+                  "text": "Redundant constructor body"
+                },
+                "fullDescription": {
+                  "text": "Reports empty bodies of secondary constructors.",
+                  "markdown": "Reports empty bodies of secondary constructors."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "FloatingPointLiteralPrecision",
+                "shortDescription": {
+                  "text": "Floating-point literal exceeds the available precision"
+                },
+                "fullDescription": {
+                  "text": "Reports floating-point literals that cannot be represented with the required precision using IEEE 754 'Float' and 'Double' types. For example, '1.9999999999999999999' has too many significant digits, so its representation as a 'Double' will be rounded to '2.0'. Specifying excess digits may be misleading as it hides the fact that computations use rounded values instead. The quick-fix replaces the literal with a rounded value that matches the actual representation of the constant. Example: 'val x: Float = 3.14159265359f' After the quick-fix is applied: 'val x: Float = 3.1415927f'",
+                  "markdown": "Reports floating-point literals that cannot be represented with the required precision using [IEEE 754](https://en.wikipedia.org/wiki/IEEE_754) `Float` and `Double` types.\n\n\nFor example, `1.9999999999999999999` has too many significant digits,\nso its representation as a `Double` will be rounded to `2.0`.\nSpecifying excess digits may be misleading as it hides the fact that computations\nuse rounded values instead.\n\n\nThe quick-fix replaces the literal with a rounded value that matches the actual representation\nof the constant.\n\n**Example:**\n\n\n      val x: Float = 3.14159265359f\n\nAfter the quick-fix is applied:\n\n\n      val x: Float = 3.1415927f\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Other problems",
+                      "index": 148,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ConvertPairConstructorToToFunction",
+                "shortDescription": {
+                  "text": "Convert Pair constructor to 'to' function"
+                },
+                "fullDescription": {
+                  "text": "Reports a 'Pair' constructor invocation that can be replaced with a 'to()' infix function call. Explicit constructor invocations may add verbosity, especially if they are used multiple times. Replacing constructor calls with 'to()' makes code easier to read and maintain. Example: 'val countries = mapOf(\n      Pair(\"France\", \"Paris\"),\n      Pair(\"Spain\", \"Madrid\"),\n      Pair(\"Germany\", \"Berlin\")\n  )' After the quick-fix is applied: 'val countries = mapOf(\n      \"France\" to \"Paris\",\n      \"Spain\" to \"Madrid\",\n      \"Germany\" to \"Berlin\"\n  )'",
+                  "markdown": "Reports a `Pair` constructor invocation that can be replaced with a `to()` infix function call.\n\n\nExplicit constructor invocations may add verbosity, especially if they are used multiple times.\nReplacing constructor calls with `to()` makes code easier to read and maintain.\n\n**Example:**\n\n\n      val countries = mapOf(\n          Pair(\"France\", \"Paris\"),\n          Pair(\"Spain\", \"Madrid\"),\n          Pair(\"Germany\", \"Berlin\")\n      )\n\nAfter the quick-fix is applied:\n\n\n      val countries = mapOf(\n          \"France\" to \"Paris\",\n          \"Spain\" to \"Madrid\",\n          \"Germany\" to \"Berlin\"\n      )\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantGetter",
+                "shortDescription": {
+                  "text": "Redundant property getter"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant property getters. Example: 'class Test {\n      val a = 1\n          get\n      val b = 1\n          get() = field\n  }' After the quick-fix is applied: 'class Test {\n      val a = 1\n      val b = 1\n  }'",
+                  "markdown": "Reports redundant property getters.\n\n**Example:**\n\n\n      class Test {\n          val a = 1\n              get\n          val b = 1\n              get() = field\n      }\n\nAfter the quick-fix is applied:\n\n\n      class Test {\n          val a = 1\n          val b = 1\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantIf",
+                "shortDescription": {
+                  "text": "Redundant 'if' statement"
+                },
+                "fullDescription": {
+                  "text": "Reports 'if' statements which can be simplified to a single statement. Example: 'fun test() {\n      if (foo()) {\n         return true\n      } else {\n         return false\n      }\n  }' After the quick-fix is applied: 'fun test() {\n      return foo()\n  }'",
+                  "markdown": "Reports `if` statements which can be simplified to a single statement.\n\n**Example:**\n\n\n      fun test() {\n          if (foo()) {\n             return true\n          } else {\n             return false\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun test() {\n          return foo()\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KDocMissingDocumentation",
+                "shortDescription": {
+                  "text": "Missing KDoc comments for public declarations"
+                },
+                "fullDescription": {
+                  "text": "Reports public declarations that do not have KDoc comments. Example: 'class A' The quick fix generates the comment block above the declaration: '/**\n   *\n   */\n  class A'",
+                  "markdown": "Reports public declarations that do not have KDoc comments.\n\n**Example:**\n\n\n      class A\n\nThe quick fix generates the comment block above the declaration:\n\n\n      /**\n       *\n       */\n      class A\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Other problems",
+                      "index": 148,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveExplicitTypeArguments",
+                "shortDescription": {
+                  "text": "Unnecessary type argument"
+                },
+                "fullDescription": {
+                  "text": "Reports function calls with type arguments that can be automatically inferred. Such type arguments are redundant and can be safely omitted. Use the 'Remove explicit type arguments' quick-fix to clean up the code. Examples: '// 'String' type can be inferred here\n  fun foo(): MutableList<String> = mutableListOf<String>()\n\n  // Here 'String' cannot be inferred, type argument is required.\n  fun bar() = mutableListOf<String>()' After the quick-fix is applied: 'fun foo(): MutableList<String> = mutableListOf() <== Updated\n\n  fun bar() = mutableListOf<String>()'",
+                  "markdown": "Reports function calls with type arguments that can be automatically inferred. Such type arguments are redundant and can be safely omitted.\n\nUse the 'Remove explicit type arguments' quick-fix to clean up the code.\n\n**Examples:**\n\n\n      // 'String' type can be inferred here\n      fun foo(): MutableList<String> = mutableListOf<String>()\n\n      // Here 'String' cannot be inferred, type argument is required.\n      fun bar() = mutableListOf<String>()\n\nAfter the quick-fix is applied:\n\n\n      fun foo(): MutableList<String> = mutableListOf() <== Updated\n\n      fun bar() = mutableListOf<String>()\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantVisibilityModifier",
+                "shortDescription": {
+                  "text": "Redundant visibility modifier"
+                },
+                "fullDescription": {
+                  "text": "Reports visibility modifiers that match the default visibility of an element ('public' for most elements, 'protected' for members that override a protected member).",
+                  "markdown": "Reports visibility modifiers that match the default visibility of an element (`public` for most elements, `protected` for members that override a protected member)."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UsePropertyAccessSyntax",
+                "shortDescription": {
+                  "text": "Accessor call that can be replaced with property access syntax"
+                },
+                "fullDescription": {
+                  "text": "Reports Java 'get' and 'set' method calls that can be replaced with the Kotlin synthetic properties. Use property access syntax quick-fix can be used to amen the code automatically. Example: '// Java:\n  public class JavaClassWithGetter {\n      private final String expr = \"result\";\n\n      // ...\n\n      public String getExpr() {\n          return expr;\n      }\n  }' '// Kotlin:\n  fun test(j: JavaClassWithGetter) {\n      // ...\n      j.getExpr() // <== A quick-fix simplifies the expression to 'j.expr'\n  }'",
+                  "markdown": "Reports Java `get` and `set` method calls that can be replaced with the Kotlin synthetic properties.\n\n**Use property access syntax** quick-fix can be used to amen the code automatically.\n\nExample:\n\n\n      // Java:\n      public class JavaClassWithGetter {\n          private final String expr = \"result\";\n\n          // ...\n\n          public String getExpr() {\n              return expr;\n          }\n      }\n\n\n      // Kotlin:\n      fun test(j: JavaClassWithGetter) {\n          // ...\n          j.getExpr() // <== A quick-fix simplifies the expression to 'j.expr'\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UseExpressionBody",
+                "shortDescription": {
+                  "text": "Expression body syntax is preferable here"
+                },
+                "fullDescription": {
+                  "text": "Reports 'return' expressions (one-liners or 'when') that can be replaced with expression body syntax. Expression body syntax is recommended by the style guide. Convert to expression body quick-fix can be used to amend the code automatically. Example: 'fun sign(x: Int): Int {\n      return when { // <== can be simplified\n          x < 0 -> -1\n          x > 0 -> 1\n          else -> 0\n      }\n  }' After the quick-fix is applied: 'fun sign(x: Int): Int = when {\n      x < 0 -> -1\n      x > 0 -> 1\n      else -> 0\n  }'",
+                  "markdown": "Reports `return` expressions (one-liners or `when`) that can be replaced with expression body syntax.\n\nExpression body syntax is recommended by the [style guide](https://kotlinlang.org/docs/coding-conventions.html#functions).\n\n**Convert to expression body** quick-fix can be used to amend the code automatically.\n\nExample:\n\n\n      fun sign(x: Int): Int {\n          return when { // <== can be simplified\n              x < 0 -> -1\n              x > 0 -> 1\n              else -> 0\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun sign(x: Int): Int = when {\n          x < 0 -> -1\n          x > 0 -> 1\n          else -> 0\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "MapGetWithNotNullAssertionOperator",
+                "shortDescription": {
+                  "text": "'map.get()' with not-null assertion operator (!!)"
+                },
+                "fullDescription": {
+                  "text": "Reports 'map.get()!!' that can be replaced with 'map.getValue()', 'map.getOrElse()', and so on. Example: 'fun test(map: Map<Int, String>): String = map.get(0)!!' After the quick-fix is applied: 'fun test(map: Map<Int, String>): String = map.getValue(0)'",
+                  "markdown": "Reports `map.get()!!` that can be replaced with `map.getValue()`, `map.getOrElse()`, and so on.\n\n**Example:**\n\n\n    fun test(map: Map<Int, String>): String = map.get(0)!!\n\nAfter the quick-fix is applied:\n\n\n    fun test(map: Map<Int, String>): String = map.getValue(0)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SortModifiers",
+                "shortDescription": {
+                  "text": "Non-canonical modifier order"
+                },
+                "fullDescription": {
+                  "text": "Reports modifiers that do not follow the order recommended by the style guide. Sort modifiers quick-fix can be used to amend the code automatically. Examples: 'private inline fun correctOrder(f: () -> Unit) {} // <== Ok\n\n  infix private fun Int.wrongOrder(expr: Int) {} // <== wrong order, quick-fix amends the modifiers to \"private infix\"'",
+                  "markdown": "Reports modifiers that do not follow the order recommended by the [style guide](https://kotlinlang.org/docs/coding-conventions.html#modifiers-order).\n\n**Sort modifiers** quick-fix can be used to amend the code automatically.\n\nExamples:\n\n\n      private inline fun correctOrder(f: () -> Unit) {} // <== Ok\n\n      infix private fun Int.wrongOrder(expr: Int) {} // <== wrong order, quick-fix amends the modifiers to \"private infix\"\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EnumEntryName",
+                "shortDescription": {
+                  "text": "Enum entry naming convention"
+                },
+                "fullDescription": {
+                  "text": "Reports enum entry names that do not follow the recommended naming conventions. Example: 'enum class Foo {\n    _Foo,\n    foo\n  }' To fix the problem rename enum entries to match the recommended naming conventions.",
+                  "markdown": "Reports enum entry names that do not follow the recommended naming conventions.\n\n**Example:**\n\n\n      enum class Foo {\n        _Foo,\n        foo\n      }\n\nTo fix the problem rename enum entries to match the recommended naming conventions."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Naming conventions",
+                      "index": 47,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceSubstringWithDropLast",
+                "shortDescription": {
+                  "text": "'substring' call should be replaced with 'dropLast' call"
+                },
+                "fullDescription": {
+                  "text": "Reports calls like 's.substring(0, s.length - x)' that can be replaced with 's.dropLast(x)'. Using corresponding functions makes your code simpler. The quick-fix replaces the 'substring' call with 'dropLast'. Example: 'fun foo(s: String) {\n      s.substring(0, s.length - 5)\n  }' After the quick-fix is applied: 'fun foo(s: String) {\n      s.dropLast(5)\n  }'",
+                  "markdown": "Reports calls like `s.substring(0, s.length - x)` that can be replaced with `s.dropLast(x)`.\n\nUsing corresponding functions makes your code simpler.\n\nThe quick-fix replaces the `substring` call with `dropLast`.\n\n**Example:**\n\n\n      fun foo(s: String) {\n          s.substring(0, s.length - 5)\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(s: String) {\n          s.dropLast(5)\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SetterBackingFieldAssignment",
+                "shortDescription": {
+                  "text": "Existing backing field without assignment"
+                },
+                "fullDescription": {
+                  "text": "Reports property setters that don't update the backing field. The quick-fix adds an assignment to the backing field. Example: 'class Test {\n      var foo: Int = 1\n          set(value) {\n          }\n  }' After the quick-fix is applied: 'class Test {\n      var foo: Int = 1\n          set(value) {\n              field = value\n          }\n  }'",
+                  "markdown": "Reports property setters that don't update the backing field.\n\nThe quick-fix adds an assignment to the backing field.\n\n**Example:**\n\n\n      class Test {\n          var foo: Int = 1\n              set(value) {\n              }\n      }\n\nAfter the quick-fix is applied:\n\n\n      class Test {\n          var foo: Int = 1\n              set(value) {\n                  field = value\n              }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CopyWithoutNamedArguments",
+                "shortDescription": {
+                  "text": "'copy' method of data class is called without named arguments"
+                },
+                "fullDescription": {
+                  "text": "Reports calls to a data class' 'copy()' method without named arguments. As all arguments of the 'copy()' function are optional, it might be hard to understand what properties are modified. Providing parameter names explicitly makes code easy to understand without navigating to the 'data class' declaration. Example: 'data class User(val name: String, val age: Int)\n\n  fun copyUser(user: User): User {\n      return user.copy(\"John\")\n  }' A quick-fix provides parameter names to all 'copy()' arguments: 'data class User(val name: String, val age: Int)\n\n  fun copyUser(user: User): User {\n      return user.copy(name = \"John\")\n  }'",
+                  "markdown": "Reports calls to a data class' `copy()` method without named arguments.\n\n\nAs all arguments of the `copy()` function are optional, it might be hard to understand what properties are modified.\nProviding parameter names explicitly makes code easy to understand without navigating to the `data class` declaration.\n\n**Example:**\n\n\n      data class User(val name: String, val age: Int)\n\n      fun copyUser(user: User): User {\n          return user.copy(\"John\")\n      }\n\nA quick-fix provides parameter names to all `copy()` arguments:\n\n\n      data class User(val name: String, val age: Int)\n\n      fun copyUser(user: User): User {\n          return user.copy(name = \"John\")\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinDeprecation",
+                "shortDescription": {
+                  "text": "Usage of redundant or deprecated syntax or deprecated symbols"
+                },
+                "fullDescription": {
+                  "text": "Reports obsolete language features and unnecessarily verbose code constructs during the code cleanup operation (Code | Code Cleanup). A quick-fix automatically replaces usages of obsolete language features or unnecessarily verbose code constructs with compact and up-to-date syntax. It also replaces deprecated symbols with their proposed substitutions.",
+                  "markdown": "Reports obsolete language features and unnecessarily verbose code constructs during the code cleanup operation (**Code \\| Code Cleanup** ).\n\n\nA quick-fix automatically replaces usages of obsolete language features or unnecessarily verbose code constructs with compact and up-to-date syntax.\n\n\nIt also replaces deprecated symbols with their proposed substitutions."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Migration",
+                      "index": 118,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceSubstringWithTake",
+                "shortDescription": {
+                  "text": "'substring' call should be replaced with 'take' call"
+                },
+                "fullDescription": {
+                  "text": "Reports calls like 's.substring(0, x)' that can be replaced with 's.take(x)'. Using 'take()' makes your code simpler. The quick-fix replaces the 'substring' call with 'take()'. Example: 'fun foo(s: String) {\n      s.substring(0, 10)\n  }' After the quick-fix is applied: 'fun foo(s: String) {\n      s.take(10)\n  }'",
+                  "markdown": "Reports calls like `s.substring(0, x)` that can be replaced with `s.take(x)`.\n\nUsing `take()` makes your code simpler.\n\nThe quick-fix replaces the `substring` call with `take()`.\n\n**Example:**\n\n\n      fun foo(s: String) {\n          s.substring(0, 10)\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(s: String) {\n          s.take(10)\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ConvertCallChainIntoSequence",
+                "shortDescription": {
+                  "text": "Call chain on collection could be converted into 'Sequence' to improve performance"
+                },
+                "fullDescription": {
+                  "text": "Reports call chain on a 'Collection' that should be converted into Sequence. Each 'Collection' transforming function (such as 'map()' or 'filter()') creates a new 'Collection' (typically 'List' or 'Set') under the hood. In case of multiple consequent calls, and a huge number of items in 'Collection', memory traffic might be significant. In such a case, using 'Sequence' is preferred. Example: 'class Entity(val key: String, val value: String)\n\n  fun getValues(lines: List<String>) = lines\n      .filter { it.isNotEmpty() }\n      .map { it.split(',', limit = 2) }\n      .filter { it.size == 2 }\n      .map { Entity(it[0], it[1]) }' A quick-fix wraps call chain into 'asSequence()' and 'toList()': 'class Entity(val key: String, val value: String)\n\n  fun getValues(lines: List<String>) = lines\n      .asSequence()\n      .filter { it.isNotEmpty() }\n      .map { it.split(',', limit = 2) }\n      .filter { it.size == 2 }\n      .map { Entity(it[0], it[1]) }\n      .toList()'",
+                  "markdown": "Reports call chain on a `Collection` that should be converted into **Sequence** .\n\nEach `Collection` transforming function (such as `map()` or `filter()`) creates a new\n`Collection` (typically `List` or `Set`) under the hood.\nIn case of multiple consequent calls, and a huge number of items in `Collection`, memory traffic might be significant.\nIn such a case, using `Sequence` is preferred.\n\n**Example:**\n\n\n      class Entity(val key: String, val value: String)\n\n      fun getValues(lines: List<String>) = lines\n          .filter { it.isNotEmpty() }\n          .map { it.split(',', limit = 2) }\n          .filter { it.size == 2 }\n          .map { Entity(it[0], it[1]) }\n\nA quick-fix wraps call chain into `asSequence()` and `toList()`:\n\n\n      class Entity(val key: String, val value: String)\n\n      fun getValues(lines: List<String>) = lines\n          .asSequence()\n          .filter { it.isNotEmpty() }\n          .map { it.split(',', limit = 2) }\n          .filter { it.size == 2 }\n          .map { Entity(it[0], it[1]) }\n          .toList()\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "AddOperatorModifier",
+                "shortDescription": {
+                  "text": "Function should have 'operator' modifier"
+                },
+                "fullDescription": {
+                  "text": "Reports a function that matches one of the operator conventions but lacks the 'operator' keyword. By adding the 'operator' modifier, you might allow function consumers to write idiomatic Kotlin code. Example: 'class Complex(val real: Double, val imaginary: Double) {\n      fun plus(other: Complex) =\n          Complex(real + other.real, imaginary + other.imaginary)\n  }\n\n  fun usage(a: Complex, b: Complex) {\n      a.plus(b)\n  }' A quick-fix adds the 'operator' modifier keyword: 'class Complex(val real: Double, val imaginary: Double) {\n      operator fun plus(other: Complex) =\n          Complex(real + other.real, imaginary + other.imaginary)\n  }\n\n  fun usage(a: Complex, b: Complex) {\n      a + b\n  }'",
+                  "markdown": "Reports a function that matches one of the operator conventions but lacks the `operator` keyword.\n\nBy adding the `operator` modifier, you might allow function consumers to write idiomatic Kotlin code.\n\n**Example:**\n\n\n      class Complex(val real: Double, val imaginary: Double) {\n          fun plus(other: Complex) =\n              Complex(real + other.real, imaginary + other.imaginary)\n      }\n\n      fun usage(a: Complex, b: Complex) {\n          a.plus(b)\n      }\n\nA quick-fix adds the `operator` modifier keyword:\n\n\n      class Complex(val real: Double, val imaginary: Double) {\n          operator fun plus(other: Complex) =\n              Complex(real + other.real, imaginary + other.imaginary)\n      }\n\n      fun usage(a: Complex, b: Complex) {\n          a + b\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "MayBeConstant",
+                "shortDescription": {
+                  "text": "Might be 'const'"
+                },
+                "fullDescription": {
+                  "text": "Reports top-level 'val' properties in objects that might be declared as 'const' for better performance and Java interoperability. Example: 'object A {\n      val foo = 1\n  }' After the quick-fix is applied: 'object A {\n      const val foo = 1\n  }'",
+                  "markdown": "Reports top-level `val` properties in objects that might be declared as `const` for better performance and Java interoperability.\n\n**Example:**\n\n\n      object A {\n          val foo = 1\n      }\n\nAfter the quick-fix is applied:\n\n\n      object A {\n          const val foo = 1\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceIsEmptyWithIfEmpty",
+                "shortDescription": {
+                  "text": "'if' condition can be replaced with lambda call"
+                },
+                "fullDescription": {
+                  "text": "Reports 'isEmpty', 'isBlank', 'isNotEmpty', or 'isNotBlank' calls in an 'if' statement to assign a default value. The quick-fix replaces the 'if' condition with 'ifEmpty' or 'ifBlank' calls. Example: 'fun test(list: List<Int>): List<Int> {\n      return if (list.isEmpty()) {\n          println()\n          foo()\n      } else {\n          list\n      }\n  }' After the quick-fix is applied: 'fun test(list: List<Int>): List<Int> {\n      return list.ifEmpty {\n          println()\n          foo()\n      }\n  }' This inspection only reports if the Kotlin language version of the project or module is 1.3 or higher.",
+                  "markdown": "Reports `isEmpty`, `isBlank`, `isNotEmpty`, or `isNotBlank` calls in an `if` statement to assign a default value.\n\nThe quick-fix replaces the `if` condition with `ifEmpty` or `ifBlank` calls.\n\n**Example:**\n\n\n      fun test(list: List<Int>): List<Int> {\n          return if (list.isEmpty()) {\n              println()\n              foo()\n          } else {\n              list\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun test(list: List<Int>): List<Int> {\n          return list.ifEmpty {\n              println()\n              foo()\n          }\n      }\n\nThis inspection only reports if the Kotlin language version of the project or module is 1.3 or higher."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceWithImportAlias",
+                "shortDescription": {
+                  "text": "Fully qualified name can be replaced with existing import alias"
+                },
+                "fullDescription": {
+                  "text": "Reports fully qualified names that can be replaced with an existing import alias. Example: 'import foo.Foo as Bar\nfun main() {\n    foo.Foo()\n}' After the quick-fix is applied: 'import foo.Foo as Bar\nfun main() {\n    Bar()\n}'",
+                  "markdown": "Reports fully qualified names that can be replaced with an existing import alias.\n\n**Example:**\n\n\n    import foo.Foo as Bar\n    fun main() {\n        foo.Foo()\n    }\n\nAfter the quick-fix is applied:\n\n\n    import foo.Foo as Bar\n    fun main() {\n        Bar()\n    }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SimplifyBooleanWithConstants",
+                "shortDescription": {
+                  "text": "Boolean expression can be simplified"
+                },
+                "fullDescription": {
+                  "text": "Reports boolean expression parts that can be reduced to constants. The quick-fix simplifies the condition. Example: 'fun use(arg: Boolean) {\n      if (false == arg) {\n\n      }\n  }' After the quick-fix is applied: 'fun use(arg: Boolean) {\n      if (!arg) {\n\n      }\n  }'",
+                  "markdown": "Reports boolean expression parts that can be reduced to constants.\n\nThe quick-fix simplifies the condition.\n\n**Example:**\n\n\n      fun use(arg: Boolean) {\n          if (false == arg) {\n\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun use(arg: Boolean) {\n          if (!arg) {\n\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantModalityModifier",
+                "shortDescription": {
+                  "text": "Redundant modality modifier"
+                },
+                "fullDescription": {
+                  "text": "Reports the modality modifiers that match the default modality of an element ('final' for most elements, 'open' for members with an 'override'). Example: 'final class Foo\n\n  open class Bar : Comparable<Bar> {\n      open override fun compareTo(other: Bar): Int = 0\n  }' After the quick-fix is applied: 'class Foo\n\n  open class Bar : Comparable<Bar> {\n      open override fun compareTo(other: Bar): Int = 0\n  }'",
+                  "markdown": "Reports the modality modifiers that match the default modality of an element (`final` for most elements, `open` for members with an `override`).\n\n**Example:**\n\n\n      final class Foo\n\n      open class Bar : Comparable<Bar> {\n          open override fun compareTo(other: Bar): Int = 0\n      }\n\nAfter the quick-fix is applied:\n\n\n      class Foo\n\n      open class Bar : Comparable<Bar> {\n          open override fun compareTo(other: Bar): Int = 0\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SimplifyAssertNotNull",
+                "shortDescription": {
+                  "text": "'assert' call can be replaced with '!!' or '?:'"
+                },
+                "fullDescription": {
+                  "text": "Reports 'assert' calls that check a not null value of the declared variable. Using '!!' or '?:' makes your code simpler. The quick-fix replaces 'assert' with '!!' or '?:' operator in the variable initializer. Example: 'fun foo(p: Array<String?>) {\n      val v = p[0]\n      assert(v != null, { \"Should be not null\" })\n  }' After the quick-fix is applied: 'fun foo(p: Array<String?>) {\n      val v = p[0] ?: error(\"Should be not null\")\n  }'",
+                  "markdown": "Reports `assert` calls that check a not null value of the declared variable.\n\nUsing `!!` or `?:` makes your code simpler.\n\nThe quick-fix replaces `assert` with `!!` or `?:` operator in the variable initializer.\n\n**Example:**\n\n\n      fun foo(p: Array<String?>) {\n          val v = p[0]\n          assert(v != null, { \"Should be not null\" })\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(p: Array<String?>) {\n          val v = p[0] ?: error(\"Should be not null\")\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ConvertNaNEquality",
+                "shortDescription": {
+                  "text": "Convert equality check with 'NaN' to 'isNaN' call"
+                },
+                "fullDescription": {
+                  "text": "Reports an equality check with 'Float.NaN' or 'Double.NaN' that should be replaced with an 'isNaN()' check. According to IEEE 754, equality check against NaN always returns 'false', even for 'NaN == NaN'. Therefore, such a check is likely to be a mistake. A quick-fix replaces comparison with 'isNaN()' check that uses a different comparison technique and handles 'NaN' values correctly. Example: 'fun check(value: Double): Boolean {\n      return Double.NaN == value\n  }' After the fix is applied: 'fun check(value: Double): Boolean {\n      return value.isNaN()\n  }'",
+                  "markdown": "Reports an equality check with `Float.NaN` or `Double.NaN` that should be replaced with an `isNaN()` check.\n\n\nAccording to IEEE 754, equality check against NaN always returns `false`, even for `NaN == NaN`.\nTherefore, such a check is likely to be a mistake.\n\nA quick-fix replaces comparison with `isNaN()` check that uses a different comparison technique and handles `NaN` values correctly.\n\n**Example:**\n\n\n      fun check(value: Double): Boolean {\n          return Double.NaN == value\n      }\n\nAfter the fix is applied:\n\n\n      fun check(value: Double): Boolean {\n          return value.isNaN()\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceManualRangeWithIndicesCalls",
+                "shortDescription": {
+                  "text": "Range can be converted to indices or iteration"
+                },
+                "fullDescription": {
+                  "text": "Reports 'until' and 'rangeTo' operators that can be replaced with 'Collection.indices' or iteration over collection inside 'for' loop. Using syntactic sugar makes your code simpler. The quick-fix replaces the manual range with the corresponding construction. Example: 'fun main(args: Array<String>) {\n      for (index in 0..args.size - 1) {\n          println(args[index])\n      }\n  }' After the quick-fix is applied: 'fun main(args: Array<String>) {\n      for (element in args) {\n          println(element)\n      }\n  }'",
+                  "markdown": "Reports `until` and `rangeTo` operators that can be replaced with `Collection.indices` or iteration over collection inside `for` loop.\n\nUsing syntactic sugar makes your code simpler.\n\nThe quick-fix replaces the manual range with the corresponding construction.\n\n**Example:**\n\n\n      fun main(args: Array<String>) {\n          for (index in 0..args.size - 1) {\n              println(args[index])\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun main(args: Array<String>) {\n          for (element in args) {\n              println(element)\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinLoggerInitializedWithForeignClass",
+                "shortDescription": {
+                  "text": "Logger initialized with foreign class"
+                },
+                "fullDescription": {
+                  "text": "Reports 'Logger' instances initialized with a class literal other than the class the 'Logger' resides in. This can happen when copy-pasting from another class. It may result in logging events under an unexpected category and incorrect filtering. Use the inspection options to specify the logger factory classes and methods recognized by this inspection. Example: 'class AnotherService\nclass MyService {\n    private val logger = LoggerFactory.getLogger(AnotherService::class.java)\n}' After the quick-fix is applied: 'class MyService {\n    private val logger = LoggerFactory.getLogger(MyService::class.java)\n}'",
+                  "markdown": "Reports `Logger` instances initialized with a class literal other than the class the `Logger` resides in.\n\n\nThis can happen when copy-pasting from another class.\nIt may result in logging events under an unexpected category and incorrect filtering.\n\n\nUse the inspection options to specify the logger factory classes and methods recognized by this inspection.\n\n**Example:**\n\n\n    class AnotherService\n    class MyService {\n        private val logger = LoggerFactory.getLogger(AnotherService::class.java)\n    }\n\nAfter the quick-fix is applied:\n\n\n    class MyService {\n        private val logger = LoggerFactory.getLogger(MyService::class.java)\n    }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Logging",
+                      "index": 158,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantAsSequence",
+                "shortDescription": {
+                  "text": "Redundant 'asSequence' call"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant 'asSequence()' call that can never have a positive performance effect. 'asSequence()' speeds up collection processing that includes multiple operations because it performs operations lazily and doesn't create intermediate collections. However, if a terminal operation (such as 'toList()') is used right after 'asSequence()', this doesn't give you any positive performance effect. Example: 'fun test(list: List<String>) {\n      list.asSequence().last()\n  }' After the quick-fix is applied: 'fun test(list: List<String>) {\n      list.last()\n  }'",
+                  "markdown": "Reports redundant `asSequence()` call that can never have a positive performance effect.\n\n\n`asSequence()` speeds up collection processing that includes multiple operations because it performs operations lazily\nand doesn't create intermediate collections.\n\n\nHowever, if a terminal operation (such as `toList()`) is used right after `asSequence()`, this doesn't give\nyou any positive performance effect.\n\n**Example:**\n\n\n      fun test(list: List<String>) {\n          list.asSequence().last()\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun test(list: List<String>) {\n          list.last()\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveToStringInStringTemplate",
+                "shortDescription": {
+                  "text": "Redundant call to 'toString()' in string template"
+                },
+                "fullDescription": {
+                  "text": "Reports calls to 'toString()' in string templates that can be safely removed. Example: 'fun foo(a: Int, b: Int) = a + b\n\n  fun test(): String {\n      return \"Foo: ${foo(0, 4).toString()}\" // 'toString()' is redundant\n  }' After the quick-fix is applied: 'fun foo(a: Int, b: Int) = a + b\n\n  fun test(): String {\n      return \"Foo: ${foo(0, 4)}\"\n  }'",
+                  "markdown": "Reports calls to `toString()` in string templates that can be safely removed.\n\n**Example:**\n\n      fun foo(a: Int, b: Int) = a + b\n\n      fun test(): String {\n          return \"Foo: ${foo(0, 4).toString()}\" // 'toString()' is redundant\n      }\n\nAfter the quick-fix is applied:\n\n      fun foo(a: Int, b: Int) = a + b\n\n      fun test(): String {\n          return \"Foo: ${foo(0, 4)}\"\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinUnusedImport",
+                "shortDescription": {
+                  "text": "Unused import directive"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant 'import' statements. Default and unused imports can be safely removed. Example: 'import kotlin.*\n  import kotlin.collections.*\n  import kotlin.comparisons.*\n  import kotlin.io.*\n  import kotlin.ranges.*\n  import kotlin.sequences.*\n  import kotlin.text.*\n\n  // jvm specific\n  import java.lang.*\n  import kotlin.jvm.*\n\n  // js specific\n  import kotlin.js.*\n\n  import java.io.* // this import is unused and could be removed\n  import java.util.*\n\n  fun foo(list: ArrayList<String>) {\n      list.add(\"\")\n  }'",
+                  "markdown": "Reports redundant `import` statements.\n\nDefault and unused imports can be safely removed.\n\n**Example:**\n\n\n      import kotlin.*\n      import kotlin.collections.*\n      import kotlin.comparisons.*\n      import kotlin.io.*\n      import kotlin.ranges.*\n      import kotlin.sequences.*\n      import kotlin.text.*\n\n      // jvm specific\n      import java.lang.*\n      import kotlin.jvm.*\n\n      // js specific\n      import kotlin.js.*\n\n      import java.io.* // this import is unused and could be removed\n      import java.util.*\n\n      fun foo(list: ArrayList<String>) {\n          list.add(\"\")\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CanBePrimaryConstructorProperty",
+                "shortDescription": {
+                  "text": "Property is explicitly assigned to constructor parameter"
+                },
+                "fullDescription": {
+                  "text": "Reports properties that are explicitly assigned to primary constructor parameters. Properties can be declared directly in the primary constructor, reducing the amount of code and increasing code readability. Example: 'class User(name: String) {\n      val name = name\n  }' A quick-fix joins the parameter and property declaration into a primary constructor parameter: 'class User(val name: String) {\n  }'",
+                  "markdown": "Reports properties that are explicitly assigned to primary constructor parameters.\n\nProperties can be declared directly in the primary constructor, reducing the amount of code and increasing code readability.\n\n**Example:**\n\n\n      class User(name: String) {\n          val name = name\n      }\n\nA quick-fix joins the parameter and property declaration into a primary constructor parameter:\n\n\n      class User(val name: String) {\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "JavaMapForEach",
+                "shortDescription": {
+                  "text": "Java Map.forEach method call should be replaced with Kotlin's forEach"
+                },
+                "fullDescription": {
+                  "text": "Reports a Java Map.'forEach' method call that can be replaced with Kotlin's forEach. Example: 'fun test(map: HashMap<Int, String>) {\n      map.forEach { (key, value) ->\n          foo(key, value)\n      }\n  }\n\n  fun foo(i: Int, s: String) {}' The quick fix removes parentheses: 'fun test(map: HashMap<Int, String>) {\n      map.forEach { key, value ->\n          foo(key, value)\n      }\n  }\n\n  fun foo(i: Int, s: String) {}'",
+                  "markdown": "Reports a Java Map.`forEach` method call that can be replaced with Kotlin's **forEach** .\n\n**Example:**\n\n\n      fun test(map: HashMap<Int, String>) {\n          map.forEach { (key, value) ->\n              foo(key, value)\n          }\n      }\n\n      fun foo(i: Int, s: String) {}\n\nThe quick fix removes parentheses:\n\n\n      fun test(map: HashMap<Int, String>) {\n          map.forEach { key, value ->\n              foo(key, value)\n          }\n      }\n\n      fun foo(i: Int, s: String) {}\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantObjectTypeCheck",
+                "shortDescription": {
+                  "text": "Non-idiomatic 'is' type check for an object"
+                },
+                "fullDescription": {
+                  "text": "Reports non-idiomatic 'is' type checks for an object. It's recommended to replace such checks with reference comparison. Example: 'object Foo\n\n  fun foo(arg: Any) = when {\n      arg is Foo -> ...\n      arg !is Foo -> ...\n  }' After the quick-fix is applied: 'object Foo\n\n  fun foo(arg: Any) = when {\n      arg === Foo -> ...\n      arg !== Foo -> ...\n  }'",
+                  "markdown": "Reports non-idiomatic `is` type checks for an object.\n\nIt's recommended to replace such checks with reference comparison.\n\n**Example:**\n\n\n      object Foo\n\n      fun foo(arg: Any) = when {\n          arg is Foo -> ...\n          arg !is Foo -> ...\n      }\n\nAfter the quick-fix is applied:\n\n\n      object Foo\n\n      fun foo(arg: Any) = when {\n          arg === Foo -> ...\n          arg !== Foo -> ...\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SuspendFunctionOnCoroutineScope",
+                "shortDescription": {
+                  "text": "Ambiguous coroutineContext due to CoroutineScope receiver of suspend function"
+                },
+                "fullDescription": {
+                  "text": "Reports calls and accesses of 'CoroutineScope' extensions or members inside suspend functions with 'CoroutineScope' receiver. When a function is 'suspend' and has 'CoroutineScope' receiver, it has ambiguous access to 'CoroutineContext' via 'kotlin.coroutines.coroutineContext' and via 'CoroutineScope.coroutineContext', and two these contexts are different in general. To improve this situation, one can wrap suspicious call inside 'coroutineScope { ... }' or get rid of 'CoroutineScope' function receiver.",
+                  "markdown": "Reports calls and accesses of `CoroutineScope` extensions or members inside suspend functions with `CoroutineScope` receiver.\n\nWhen a function is `suspend` and has `CoroutineScope` receiver,\nit has ambiguous access to `CoroutineContext` via `kotlin.coroutines.coroutineContext` and via `CoroutineScope.coroutineContext`,\nand two these contexts are different in general.\n\n\nTo improve this situation, one can wrap suspicious call inside `coroutineScope { ... }` or\nget rid of `CoroutineScope` function receiver."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "DifferentMavenStdlibVersion",
+                "shortDescription": {
+                  "text": "Library and maven plugin versions are different"
+                },
+                "fullDescription": {
+                  "text": "Reports different Kotlin stdlib and compiler versions. Using different versions of the Kotlin compiler and the standard library can lead to unpredictable runtime problems and should be avoided.",
+                  "markdown": "Reports different Kotlin stdlib and compiler versions.\n\nUsing different versions of the Kotlin compiler and the standard library can lead to unpredictable\nruntime problems and should be avoided."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ImplicitNullableNothingType",
+                "shortDescription": {
+                  "text": "Implicit `Nothing?` type"
+                },
+                "fullDescription": {
+                  "text": "Reports variables and functions with the implicit Nothing? type. Example: 'fun foo() = null' The quick fix specifies the return type explicitly: 'fun foo(): Nothing? = null'",
+                  "markdown": "Reports variables and functions with the implicit **Nothing?** type.\n\n**Example:**\n\n\n      fun foo() = null\n\nThe quick fix specifies the return type explicitly:\n\n\n      fun foo(): Nothing? = null\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceAssociateFunction",
+                "shortDescription": {
+                  "text": "'associate' can be replaced with 'associateBy' or 'associateWith'"
+                },
+                "fullDescription": {
+                  "text": "Reports calls to 'associate()' and 'associateTo()' that can be replaced with 'associateBy()' or 'associateWith()'. Both functions accept a transformer function applied to elements of a given sequence or collection (as a receiver). The pairs are then used to build the resulting 'Map'. Given the transformer refers to 'it', the 'associate[To]()' call can be replaced with more performant 'associateBy()' or 'associateWith()'. Examples: 'fun getKey(i: Int) = 1L\n  fun getValue(i: Int) = 1L\n\n  fun test() {\n      arrayOf(1).associate { getKey(it) to it }  // replaceable 'associate()'\n      listOf(1).associate { it to getValue(it) } // replaceable 'associate()'\n  }' After the quick-fix is applied: 'fun getKey(i: Int) = 1L\n  fun getValue(i: Int) = 1L\n\n  fun test() {\n      arrayOf(1).associateBy { getKey(it) }\n      listOf(1).associateWith { getValue(it) }\n  }'",
+                  "markdown": "Reports calls to `associate()` and `associateTo()` that can be replaced with `associateBy()` or `associateWith()`.\n\n\nBoth functions accept a transformer function applied to elements of a given sequence or collection (as a receiver).\nThe pairs are then used to build the resulting `Map`.\n\n\nGiven the transformer refers to `it`, the `associate[To]()` call can be replaced with more performant `associateBy()`\nor `associateWith()`.\n\n**Examples:**\n\n      fun getKey(i: Int) = 1L\n      fun getValue(i: Int) = 1L\n\n      fun test() {\n          arrayOf(1).associate { getKey(it) to it }  // replaceable 'associate()'\n          listOf(1).associate { it to getValue(it) } // replaceable 'associate()'\n      }\n\nAfter the quick-fix is applied:\n\n      fun getKey(i: Int) = 1L\n      fun getValue(i: Int) = 1L\n\n      fun test() {\n          arrayOf(1).associateBy { getKey(it) }\n          listOf(1).associateWith { getValue(it) }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ObsoleteExperimentalCoroutines",
+                "shortDescription": {
+                  "text": "Experimental coroutines usages are deprecated since 1.3"
+                },
+                "fullDescription": {
+                  "text": "Reports code that uses experimental coroutines. Such usages are incompatible with Kotlin 1.3+ and should be updated.",
+                  "markdown": "Reports code that uses experimental coroutines.\n\nSuch usages are incompatible with Kotlin 1.3+ and should be updated."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "ideaSeverity": "ERROR",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Migration",
+                      "index": 118,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "LiftReturnOrAssignment",
+                "shortDescription": {
+                  "text": "Return or assignment can be lifted out"
+                },
+                "fullDescription": {
+                  "text": "Reports 'if', 'when', and 'try' statements that can be converted to expressions by lifting the 'return' statement or an assignment out. Example: 'fun foo(arg: Int): String {\n      when (arg) {\n          0 -> return \"Zero\"\n          1 -> return \"One\"\n          else -> return \"Multiple\"\n      }\n  }' After the quick-fix is applied: 'fun foo(arg: Int): String {\n      return when (arg) {\n          0 -> \"Zero\"\n          1 -> \"One\"\n          else -> \"Multiple\"\n      }\n  }'",
+                  "markdown": "Reports `if`, `when`, and `try` statements that can be converted to expressions by lifting the `return` statement or an assignment out.\n\n**Example:**\n\n\n      fun foo(arg: Int): String {\n          when (arg) {\n              0 -> return \"Zero\"\n              1 -> return \"One\"\n              else -> return \"Multiple\"\n          }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(arg: Int): String {\n          return when (arg) {\n              0 -> \"Zero\"\n              1 -> \"One\"\n              else -> \"Multiple\"\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SimplifyWhenWithBooleanConstantCondition",
+                "shortDescription": {
+                  "text": "Simplifiable 'when'"
+                },
+                "fullDescription": {
+                  "text": "Reports 'when' expressions with the constant 'true' or 'false' branches. Simplify \"when\" quick-fix can be used to amend the code automatically. Examples: 'fun redundant() {\n      when { // <== redundant, quick-fix simplifies the when expression to \"println(\"true\")\"\n          true -> println(\"true\")\n          else -> println(\"false\")\n      }\n  }'",
+                  "markdown": "Reports `when` expressions with the constant `true` or `false` branches.\n\n**Simplify \"when\"** quick-fix can be used to amend the code automatically.\n\nExamples:\n\n\n      fun redundant() {\n          when { // <== redundant, quick-fix simplifies the when expression to \"println(\"true\")\"\n              true -> println(\"true\")\n              else -> println(\"false\")\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinConstantConditions",
+                "shortDescription": {
+                  "text": "Constant conditions"
+                },
+                "fullDescription": {
+                  "text": "Reports non-trivial conditions and values that are statically known to be always true, false, null or zero. While sometimes intended, often this is a sign of logical error in the program. Additionally, reports never reachable 'when' branches and some expressions that are statically known to fail always. Examples: 'fun process(x: Int?) {\n  val isNull = x == null\n  if (!isNull) {\n    if (x != null) {} // condition is always true\n    require(x!! < 0 && x > 10) // condition is always false\n  } else {\n    println(x!!) // !! operator will always fail\n  }\n}\nfun process(v: Any) {\n  when(v) {\n    is CharSequence -> println(v as Int) // cast will always fail\n    is String -> println(v) // branch is unreachable\n  }\n}' New in 2021.3",
+                  "markdown": "Reports non-trivial conditions and values that are statically known to be always true, false, null or zero. While sometimes intended, often this is a sign of logical error in the program. Additionally, reports never reachable `when` branches and some expressions that are statically known to fail always.\n\nExamples:\n\n\n    fun process(x: Int?) {\n      val isNull = x == null\n      if (!isNull) {\n        if (x != null) {} // condition is always true\n        require(x!! < 0 && x > 10) // condition is always false\n      } else {\n        println(x!!) // !! operator will always fail\n      }\n    }\n    fun process(v: Any) {\n      when(v) {\n        is CharSequence -> println(v as Int) // cast will always fail\n        is String -> println(v) // branch is unreachable\n      }\n    }\n\nNew in 2021.3"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ForEachParameterNotUsed",
+                "shortDescription": {
+                  "text": "Iterated elements are not used in forEach"
+                },
+                "fullDescription": {
+                  "text": "Reports 'forEach' loops that do not use iterable values. Example: 'listOf(1, 2, 3).forEach { }' The quick fix introduces anonymous parameter in the 'forEach' section: 'listOf(1, 2, 3).forEach { _ -> }'",
+                  "markdown": "Reports `forEach` loops that do not use iterable values.\n\n**Example:**\n\n\n      listOf(1, 2, 3).forEach { }\n\nThe quick fix introduces anonymous parameter in the `forEach` section:\n\n\n      listOf(1, 2, 3).forEach { _ -> }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "LeakingThis",
+                "shortDescription": {
+                  "text": "Leaking 'this' in constructor"
+                },
+                "fullDescription": {
+                  "text": "Reports unsafe operations with 'this' during object construction including: Accessing a non-final property during class initialization: from a constructor or property initialization Calling a non-final function during class initialization Using 'this' as a function argument in a constructor of a non-final class If other classes inherit from the given class, they may not be fully initialized at the moment when an unsafe operation is carried out. Example: 'abstract class Base {\n      val code = calculate()\n      abstract fun calculate(): Int\n  }\n\n  class Derived(private val x: Int) : Base() {\n      override fun calculate() = x\n  }\n\n  fun testIt() {\n      println(Derived(42).code) // Expected: 42, actual: 0\n  }'",
+                  "markdown": "Reports unsafe operations with `this` during object construction including:\n\n* Accessing a non-final property during class initialization: from a constructor or property initialization\n* Calling a non-final function during class initialization\n* Using `this` as a function argument in a constructor of a non-final class\n\n\nIf other classes inherit from the given class,\nthey may not be fully initialized at the moment when an unsafe operation is carried out.\n\n**Example:**\n\n\n      abstract class Base {\n          val code = calculate()\n          abstract fun calculate(): Int\n      }\n\n      class Derived(private val x: Int) : Base() {\n          override fun calculate() = x\n      }\n\n      fun testIt() {\n          println(Derived(42).code) // Expected: 42, actual: 0\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "AddVarianceModifier",
+                "shortDescription": {
+                  "text": "Type parameter can have 'in' or 'out' variance"
+                },
+                "fullDescription": {
+                  "text": "Reports type parameters that can have 'in' or 'out' variance. Using 'in' and 'out' variance provides more precise type inference in Kotlin and clearer code semantics. Example: 'class Box<T>(val obj: T)\n\n  fun consumeString(box: Box<String>) {}\n  fun consumeCharSequence(box: Box<CharSequence>) {}\n\n  fun usage(box: Box<String>) {\n      consumeString(box)\n      consumeCharSequence(box) // Compilation error\n  }' A quick-fix adds the matching variance modifier: 'class Box<out T>(val obj: T)\n\n  fun consumeString(box: Box<String>) {}\n  fun consumeCharSequence(box: Box<CharSequence>) {}\n\n  fun usage(box: Box<String>) ++{\n      consumeString(box)\n      consumeCharSequence(box) // OK\n  }'",
+                  "markdown": "Reports type parameters that can have `in` or `out` variance.\n\nUsing `in` and `out` variance provides more precise type inference in Kotlin and clearer code semantics.\n\n**Example:**\n\n\n      class Box<T>(val obj: T)\n\n      fun consumeString(box: Box<String>) {}\n      fun consumeCharSequence(box: Box<CharSequence>) {}\n\n      fun usage(box: Box<String>) {\n          consumeString(box)\n          consumeCharSequence(box) // Compilation error\n      }\n\nA quick-fix adds the matching variance modifier:\n\n\n      class Box<out T>(val obj: T)\n\n      fun consumeString(box: Box<String>) {}\n      fun consumeCharSequence(box: Box<CharSequence>) {}\n\n      fun usage(box: Box<String>) ++{\n          consumeString(box)\n          consumeCharSequence(box) // OK\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveForLoopIndices",
+                "shortDescription": {
+                  "text": "Unused loop index"
+                },
+                "fullDescription": {
+                  "text": "Reports 'for' loops iterating over a collection using the 'withIndex()' function and not using the index variable. Use the \"Remove indices in 'for' loop\" quick-fix to clean up the code. Examples: 'fun foo(bar: List<String>) {\n     for ((index : Int, value: String) in bar.withIndex()) { // <== 'index' is unused\n         println(value)\n     }\n  }' After the quick-fix is applied: 'fun foo(bar: List<String>) {\n      for (value: String in bar) { // <== '.withIndex()' and 'index' are removed\n          println(value)\n      }\n  }'",
+                  "markdown": "Reports `for` loops iterating over a collection using the `withIndex()` function and not using the index variable.\n\nUse the \"Remove indices in 'for' loop\" quick-fix to clean up the code.\n\n**Examples:**\n\n\n      fun foo(bar: List<String>) {\n         for ((index : Int, value: String) in bar.withIndex()) { // <== 'index' is unused\n             println(value)\n         }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(bar: List<String>) {\n          for (value: String in bar) { // <== '.withIndex()' and 'index' are removed\n              println(value)\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantSuspendModifier",
+                "shortDescription": {
+                  "text": "Redundant 'suspend' modifier"
+                },
+                "fullDescription": {
+                  "text": "Reports 'suspend' modifier as redundant if no other suspending functions are called inside.",
+                  "markdown": "Reports `suspend` modifier as redundant if no other suspending functions are called inside."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SuspiciousAsDynamic",
+                "shortDescription": {
+                  "text": "Suspicious 'asDynamic' member invocation"
+                },
+                "fullDescription": {
+                  "text": "Reports usages of 'asDynamic' function on a receiver of dynamic type. 'asDynamic' function has no effect for expressions of dynamic type. 'asDynamic' function on a receiver of dynamic type can lead to runtime problems because 'asDynamic' will be executed in JavaScript environment, and such function may not be present at runtime. The intended way is to use this function on usual Kotlin type. Remove \"asDynamic\" invocation quick-fix can be used to amend the code automatically. Example: 'fun wrongUsage(d: Dynamic) {\n     d.asDynamic().foo() // <== redundant, quick-fix simplifies the call expression to \"d.foo()\"\n  }'",
+                  "markdown": "Reports usages of `asDynamic` function on a receiver of dynamic type.\n\n`asDynamic` function has no effect for expressions of dynamic type.\n\n`asDynamic` function on a receiver of dynamic type can lead to runtime problems because `asDynamic`\nwill be executed in JavaScript environment, and such function may not be present at runtime.\nThe intended way is to use this function on usual Kotlin type.\n\n**Remove \"asDynamic\" invocation** quick-fix can be used to amend the code automatically.\n\nExample:\n\n\n      fun wrongUsage(d: Dynamic) {\n         d.asDynamic().foo() // <== redundant, quick-fix simplifies the call expression to \"d.foo()\"\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "FromClosedRangeMigration",
+                "shortDescription": {
+                  "text": "MIN_VALUE step in fromClosedRange() since 1.3"
+                },
+                "fullDescription": {
+                  "text": "Reports 'IntProgression.fromClosedRange()' and 'LongProgression.fromClosedRange()' with 'MIN_VALUE' step. It is prohibited to call 'IntProgression.fromClosedRange()' and 'LongProgression.fromClosedRange()' with 'MIN_VALUE' step. All such calls should be checked during migration to Kotlin 1.3+. Example: 'IntProgression.fromClosedRange(12, 143, Int.MIN_VALUE)' To fix the problem change the step of the progression.",
+                  "markdown": "Reports `IntProgression.fromClosedRange()` and `LongProgression.fromClosedRange()` with `MIN_VALUE` step.\n\n\nIt is prohibited to call `IntProgression.fromClosedRange()` and `LongProgression.fromClosedRange()` with\n`MIN_VALUE` step. All such calls should be checked during migration to Kotlin 1.3+.\n\n**Example:**\n\n\n      IntProgression.fromClosedRange(12, 143, Int.MIN_VALUE)\n\nTo fix the problem change the step of the progression."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Migration",
+                      "index": 118,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveRedundantBackticks",
+                "shortDescription": {
+                  "text": "Redundant backticks"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant backticks in references. Some of the Kotlin keywords are valid identifiers in Java, for example: 'in', 'object', 'is'. If a Java library uses a Kotlin keyword for a method, you can still call the method escaping it with the backtick character ('`'), for example, 'foo.`is`(bar)'. Sometimes this escaping is redundant and can be safely omitted. The inspection discovers and reports such cases and is paired with the 'Remove redundant backticks' quick-fix, which allows you to amend the highlighted code. Examples: 'fun `is`(x: String) {}\n  fun foo() {\n      `is`(\"bar\") // 'is' is a keyword, backticks are required\n  }\n\n  fun `test that smth works as designed`() {} // OK, complex identifier for readability improvement\n\n  val `a` = 1  // no need for backticks'",
+                  "markdown": "Reports redundant backticks in references.\n\n\nSome of the Kotlin keywords are valid identifiers in Java, for example: `in`, `object`, `is`.\nIf a Java library uses a Kotlin keyword for a method, you can still call the method escaping it\nwith the backtick character (`````), for example, ``foo.`is`(bar)``.\nSometimes this escaping is redundant and can be safely omitted. The inspection discovers and reports such cases and is\npaired with the 'Remove redundant backticks' quick-fix, which allows you to amend the highlighted code.\n\n**Examples:**\n\n\n      fun `is`(x: String) {}\n      fun foo() {\n          `is`(\"bar\") // 'is' is a keyword, backticks are required\n      }\n\n      fun `test that smth works as designed`() {} // OK, complex identifier for readability improvement\n\n      val `a` = 1  // no need for backticks\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SimplifyNestedEachInScopeFunction",
+                "shortDescription": {
+                  "text": "Scope function with nested forEach can be simplified"
+                },
+                "fullDescription": {
+                  "text": "Reports 'forEach' functions in the scope functions such as 'also' or 'apply' that can be simplified. Convert forEach call to onEach quick-fix can be used to amend the code automatically. Examples: 'fun test(list: List<Int>) {\n      val x = list.also { it.forEach { it + 4 } }.toString()\n      val y = list.apply { forEach { println(it) } }\n  }' After the quick-fix is applied: 'fun test(list: List<Int>) {\n      val x = list.onEach { it + 4 }.toString()\n      val y = list.onEach { println(it) }\n  }'",
+                  "markdown": "Reports `forEach` functions in the scope functions such as `also` or `apply` that can be simplified.\n\n**Convert forEach call to onEach** quick-fix can be used to amend the code automatically.\n\nExamples:\n\n\n      fun test(list: List<Int>) {\n          val x = list.also { it.forEach { it + 4 } }.toString()\n          val y = list.apply { forEach { println(it) } }\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun test(list: List<Int>) {\n          val x = list.onEach { it + 4 }.toString()\n          val y = list.onEach { println(it) }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UnsafeCastFromDynamic",
+                "shortDescription": {
+                  "text": "Implicit (unsafe) cast from dynamic type"
+                },
+                "fullDescription": {
+                  "text": "Reports expressions with a dynamic type in the specified inspection scope that are implicitly cast to another type.",
+                  "markdown": "Reports expressions with a dynamic type in the specified inspection scope that are implicitly cast to another type."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PublicApiImplicitType",
+                "shortDescription": {
+                  "text": "Public API declaration with implicit return type"
+                },
+                "fullDescription": {
+                  "text": "Reports 'public' and 'protected' functions and properties that have an implicit return type. For API stability reasons, it's recommended to specify such types explicitly. Example: 'fun publicFunctionWhichAbusesTypeInference() =\n      otherFunctionWithNotObviousReturnType() ?: yetAnotherFunctionWithNotObviousReturnType()' After the quick-fix is applied: 'fun publicFunctionWhichAbusesTypeInference(): Api =\n      otherFunctionWithNotObviousReturnType() ?: yetAnotherFunctionWithNotObviousReturnType()'",
+                  "markdown": "Reports `public` and `protected` functions and properties that have an implicit return type.\nFor API stability reasons, it's recommended to specify such types explicitly.\n\n**Example:**\n\n\n      fun publicFunctionWhichAbusesTypeInference() =\n          otherFunctionWithNotObviousReturnType() ?: yetAnotherFunctionWithNotObviousReturnType()\n\nAfter the quick-fix is applied:\n\n\n      fun publicFunctionWhichAbusesTypeInference(): Api =\n          otherFunctionWithNotObviousReturnType() ?: yetAnotherFunctionWithNotObviousReturnType()\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Other problems",
+                      "index": 148,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceMapIndexedWithListGenerator",
+                "shortDescription": {
+                  "text": "Replace 'mapIndexed' with List generator"
+                },
+                "fullDescription": {
+                  "text": "Reports a 'mapIndexed' call that can be replaced by 'List' generator. Example: 'val a = listOf(1, 2, 3).mapIndexed { i, _ ->\n      i + 42\n  }' After the quick-fix is applied: 'val a = List(listOf(1, 2, 3).size) { i ->\n          i + 42\n  }'",
+                  "markdown": "Reports a `mapIndexed` call that can be replaced by `List` generator.\n\n**Example:**\n\n\n      val a = listOf(1, 2, 3).mapIndexed { i, _ ->\n          i + 42\n      }\n\nAfter the quick-fix is applied:\n\n\n      val a = List(listOf(1, 2, 3).size) { i ->\n              i + 42\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ControlFlowWithEmptyBody",
+                "shortDescription": {
+                  "text": "Control flow with empty body"
+                },
+                "fullDescription": {
+                  "text": "Reports 'if', 'while', 'do' or 'for' statements with empty bodies. While occasionally intended, this construction is confusing and often the result of a typo. A quick-fix removes a statement. Example: 'if (a > b) {}'",
+                  "markdown": "Reports `if`, `while`, `do` or `for` statements with empty bodies.\n\nWhile occasionally intended, this construction is confusing and often the result of a typo.\n\nA quick-fix removes a statement.\n\n**Example:**\n\n\n      if (a > b) {}\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "LoopToCallChain",
+                "shortDescription": {
+                  "text": "Loop can be replaced with stdlib operations"
+                },
+                "fullDescription": {
+                  "text": "Reports 'for' loops that can be replaced with a sequence of stdlib operations (like 'map', 'filter', and so on). Example: 'fun foo(list: List<String>): List<Int> {\n  val result = ArrayList<Int>()\n  for (s in list) {\n     if (s.length > 0)\n       result.add(s.hashCode())\n     }\n  return result\n}' After the quick-fix is applied: 'fun foo(list: List<String>): List<Int> {\n  val result = list\n    .filter { it.length > 0 }\n    .map { it.hashCode() }\n  return result\n}'",
+                  "markdown": "Reports `for` loops that can be replaced with a sequence of stdlib operations (like `map`, `filter`, and so on).\n\n**Example:**\n\n\n    fun foo(list: List<String>): List<Int> {\n      val result = ArrayList<Int>()\n      for (s in list) {\n         if (s.length > 0)\n           result.add(s.hashCode())\n         }\n      return result\n    }\n\nAfter the quick-fix is applied:\n\n\n    fun foo(list: List<String>): List<Int> {\n      val result = list\n        .filter { it.length > 0 }\n        .map { it.hashCode() }\n      return result\n    }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RemoveEmptyClassBody",
+                "shortDescription": {
+                  "text": "Replace empty class body"
+                },
+                "fullDescription": {
+                  "text": "Reports declarations of classes and objects with an empty body. Use the 'Remove redundant empty class body' quick-fix to clean up the code. Examples: 'class EmptyA() {} // <== empty body\n\n  class EmptyB {\n      companion object {} // <== empty body\n  }\n\n  fun emptyC() {\n     object {} // <== anonymous object, it's ok (not reported)\n  }' After the quick fix is applied: 'class EmptyA()\n\n  class EmptyB {\n      companion object\n  }\n\n  fun emptyC() {\n     object {}\n  }'",
+                  "markdown": "Reports declarations of classes and objects with an empty body.\n\nUse the 'Remove redundant empty class body' quick-fix to clean up the code.\n\n**Examples:**\n\n\n      class EmptyA() {} // <== empty body\n\n      class EmptyB {\n          companion object {} // <== empty body\n      }\n\n      fun emptyC() {\n         object {} // <== anonymous object, it's ok (not reported)\n      }\n\nAfter the quick fix is applied:\n\n\n      class EmptyA()\n\n      class EmptyB {\n          companion object\n      }\n\n      fun emptyC() {\n         object {}\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CanBeParameter",
+                "shortDescription": {
+                  "text": "Constructor parameter is never used as a property"
+                },
+                "fullDescription": {
+                  "text": "Reports primary constructor parameters that can have 'val' or 'var' removed. Class properties declared in the constructor increase memory consumption. If the parameter value is only used in the constructor, you can omit them. Note that the referenced object might be garbage-collected earlier. Example: 'class Task(val name: String) {\n      init {\n          print(\"Task created: $name\")\n      }\n  }' A quick-fix removes the extra 'val' or 'var' keyword: 'class Task(name: String) {\n      init {\n          print(\"Task created: $name\")\n      }\n  }'",
+                  "markdown": "Reports primary constructor parameters that can have `val` or `var` removed.\n\n\nClass properties declared in the constructor increase memory consumption.\nIf the parameter value is only used in the constructor, you can omit them.\n\nNote that the referenced object might be garbage-collected earlier.\n\n**Example:**\n\n\n      class Task(val name: String) {\n          init {\n              print(\"Task created: $name\")\n          }\n      }\n\nA quick-fix removes the extra `val` or `var` keyword:\n\n\n      class Task(name: String) {\n          init {\n              print(\"Task created: $name\")\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantReturnLabel",
+                "shortDescription": {
+                  "text": "Redundant 'return' label"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant return labels outside of lambda expressions. Example: 'fun test() {\n      return@test\n  }' After the quick-fix is applied: 'fun test() {\n      return\n  }'",
+                  "markdown": "Reports redundant return labels outside of lambda expressions.\n\n**Example:**\n\n\n      fun test() {\n          return@test\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun test() {\n          return\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PackageName",
+                "shortDescription": {
+                  "text": "Package naming convention"
+                },
+                "fullDescription": {
+                  "text": "Reports package names that do not follow the naming conventions. You can specify the required pattern in the inspection options. Recommended naming conventions: names of packages are always lowercase and should not contain underscores. Example: 'org.example.project' Using multi-word names is generally discouraged, but if you do need to use multiple words, you can either just concatenate them together or use camel case Example: 'org.example.myProject'",
+                  "markdown": "Reports package names that do not follow the naming conventions.\n\nYou can specify the required pattern in the inspection options.\n\n[Recommended naming conventions](https://kotlinlang.org/docs/coding-conventions.html#naming-rules): names of packages are always lowercase and should not contain underscores.\n\n**Example:**\n`org.example.project`\n\nUsing multi-word names is generally discouraged, but if you do need to use multiple words, you can either just concatenate them together or use camel case\n\n**Example:**\n`org.example.myProject`"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Naming conventions",
+                      "index": 47,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ProhibitUseSiteTargetAnnotationsOnSuperTypesMigration",
+                "shortDescription": {
+                  "text": "Meaningless annotations targets on superclass"
+                },
+                "fullDescription": {
+                  "text": "Reports meaningless annotation targets on superclasses since Kotlin 1.4. Annotation targets such as '@get:' are meaningless on superclasses and are prohibited. Example: 'interface Foo\n\n  annotation class Ann\n\n  class E : @field:Ann @get:Ann @set:Ann @setparam:Ann Foo' After the quick-fix is applied: 'interface Foo\n\n  annotation class Ann\n\n  class E : Foo' This inspection only reports if the Kotlin language level of the project or module is 1.4 or higher.",
+                  "markdown": "Reports meaningless annotation targets on superclasses since Kotlin 1.4.\n\nAnnotation targets such as `@get:` are meaningless on superclasses and are prohibited.\n\n**Example:**\n\n\n      interface Foo\n\n      annotation class Ann\n\n      class E : @field:Ann @get:Ann @set:Ann @setparam:Ann Foo\n\nAfter the quick-fix is applied:\n\n\n      interface Foo\n\n      annotation class Ann\n\n      class E : Foo\n\nThis inspection only reports if the Kotlin language level of the project or module is 1.4 or higher."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "ideaSeverity": "ERROR",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Migration",
+                      "index": 118,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceWithEnumMap",
+                "shortDescription": {
+                  "text": "'HashMap' can be replaced with 'EnumMap'"
+                },
+                "fullDescription": {
+                  "text": "Reports 'hashMapOf' function or 'HashMap' constructor calls that can be replaced with an 'EnumMap' constructor call. Using 'EnumMap' constructor makes your code simpler. The quick-fix replaces the function call with the 'EnumMap' constructor call. Example: 'enum class E {\n      A, B\n  }\n\n  fun getMap(): Map<E, String> = hashMapOf()' After the quick-fix is applied: 'enum class E {\n      A, B\n  }\n\n  fun getMap(): Map<E, String> = EnumMap(E::class.java)'",
+                  "markdown": "Reports `hashMapOf` function or `HashMap` constructor calls that can be replaced with an `EnumMap` constructor call.\n\nUsing `EnumMap` constructor makes your code simpler.\n\nThe quick-fix replaces the function call with the `EnumMap` constructor call.\n\n**Example:**\n\n\n      enum class E {\n          A, B\n      }\n\n      fun getMap(): Map<E, String> = hashMapOf()\n\nAfter the quick-fix is applied:\n\n\n      enum class E {\n          A, B\n      }\n\n      fun getMap(): Map<E, String> = EnumMap(E::class.java)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Other problems",
+                      "index": 148,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SuspiciousCollectionReassignment",
+                "shortDescription": {
+                  "text": "Augmented assignment creates a new collection under the hood"
+                },
+                "fullDescription": {
+                  "text": "Reports augmented assignment ('+=') expressions on read-only 'Collection'. Augment assignment ('+=') expression on read-only 'Collection' doesn't modify the target collection, it creates a new one under the hood which can be misleading and lead to performance issues. Change type to mutable quick-fix can be used to amend the code automatically. Example: 'fun test() {\n      var list = listOf(0)\n      list += 42 // new list is created, variable 'list' still contains only '0'\n  }' After the quick-fix is applied: 'fun test() {\n      val list = mutableListOf(0)\n      list += 42\n  }'",
+                  "markdown": "Reports augmented assignment (`+=`) expressions on read-only `Collection`.\n\nAugment assignment (`+=`) expression on read-only `Collection` doesn't modify the target collection,\nit creates a new one under the hood which can be misleading and lead to performance issues.\n\n**Change type to mutable** quick-fix can be used to amend the code automatically.\n\nExample:\n\n\n      fun test() {\n          var list = listOf(0)\n          list += 42 // new list is created, variable 'list' still contains only '0'\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun test() {\n          val list = mutableListOf(0)\n          list += 42\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantNotNullExtensionReceiverOfInline",
+                "shortDescription": {
+                  "text": "'inline fun' extension receiver can be explicitly nullable until Kotlin 1.2"
+                },
+                "fullDescription": {
+                  "text": "Reports inline functions with non-nullable extension receivers which don't use the fact that extension receiver is not nullable. Before Kotlin 1.2, calls of 'inline fun' with flexible nullable extension receiver (a platform type with an unknown nullability) did not include nullability checks in bytecode. Since Kotlin 1.2, nullability checks are included into the bytecode (see KT-12899). Thus functions which do not use the fact that extension receiver is not nullable are dangerous in Kotlin until 1.2 and it's recommended to make such functions to have nullable receiver. Example: 'inline fun String.greet() {\n      println(\"Hello, $this!\")\n  }\n\n  fun main() {\n      // `System.getProperty` returns not denotable `String!` type\n      val user = System.getProperty(\"user.name\")\n      user.greet()\n  }' After the quick-fix is applied: 'inline fun String.greet() {\n      println(\"Hello, $this!\")\n  }\n\n  fun main() {\n      // `System.getProperty` returns not denotable `String!` type\n      val user = System.getProperty(\"user.name\")\n      user.greet()\n  }' This inspection only reports if the Kotlin language level of the project or module is lower than 1.2.",
+                  "markdown": "Reports inline functions with non-nullable extension receivers which don't use the fact that extension receiver is not nullable.\n\n\nBefore Kotlin 1.2, calls of `inline fun` with flexible nullable extension receiver (a platform type with an unknown\nnullability) did not include nullability checks in bytecode. Since Kotlin 1.2, nullability checks are included into the bytecode\n(see [KT-12899](https://youtrack.jetbrains.com/issue/KT-12899)).\n\n\nThus functions which do not use the fact that extension receiver is not nullable are dangerous in Kotlin until 1.2 and it's\nrecommended to make such functions to have nullable receiver.\n\n**Example:**\n\n\n      inline fun String.greet() {\n          println(\"Hello, $this!\")\n      }\n\n      fun main() {\n          // `System.getProperty` returns not denotable `String!` type\n          val user = System.getProperty(\"user.name\")\n          user.greet()\n      }\n\nAfter the quick-fix is applied:\n\n\n      inline fun String.greet() {\n          println(\"Hello, $this!\")\n      }\n\n      fun main() {\n          // `System.getProperty` returns not denotable `String!` type\n          val user = System.getProperty(\"user.name\")\n          user.greet()\n      }\n\nThis inspection only reports if the Kotlin language level of the project or module is lower than 1.2."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Java interop issues",
+                      "index": 54,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantElvisReturnNull",
+                "shortDescription": {
+                  "text": "Redundant '?: return null'"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant '?: return null' Example: 'fun foo(): Int? {\n      ...\n  }\n\n  fun test() : Int? {\n      return foo() ?: return null\n  }' After the quick-fix is applied: 'fun foo(): Int? {\n      ...\n  }\n\n  fun test() : Int? {\n      return foo()\n  }'",
+                  "markdown": "Reports redundant `?: return null`\n\n**Example:**\n\n\n      fun foo(): Int? {\n          ...\n      }\n\n      fun test() : Int? {\n          return foo() ?: return null\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(): Int? {\n          ...\n      }\n\n      fun test() : Int? {\n          return foo()\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PrivatePropertyName",
+                "shortDescription": {
+                  "text": "Private property naming convention"
+                },
+                "fullDescription": {
+                  "text": "Reports private property names that do not follow the recommended naming conventions. Consistent naming allows for easier code reading and understanding. According to the Kotlin official style guide, private property names should start with a lowercase letter and use camel case. Optionally, underscore prefix is allowed but only for private properties. It is possible to introduce other naming rules by changing the \"Pattern\" regular expression. Example: 'val _My_Cool_Property = \"\"' A quick-fix renames the class according to the Kotlin naming conventions: 'val _myCoolProperty = \"\"'",
+                  "markdown": "Reports private property names that do not follow the recommended naming conventions.\n\n\nConsistent naming allows for easier code reading and understanding.\nAccording to the [Kotlin official style guide](https://kotlinlang.org/docs/coding-conventions.html#naming-rules),\nprivate property names should start with a lowercase letter and use camel case.\nOptionally, underscore prefix is allowed but only for **private** properties.\n\nIt is possible to introduce other naming rules by changing the \"Pattern\" regular expression.\n\n**Example:**\n\n\n      val _My_Cool_Property = \"\"\n\nA quick-fix renames the class according to the Kotlin naming conventions:\n\n\n      val _myCoolProperty = \"\"\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Naming conventions",
+                      "index": 47,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ObsoleteKotlinJsPackages",
+                "shortDescription": {
+                  "text": "'kotlin.browser' and 'kotlin.dom' packages are deprecated since 1.4"
+                },
+                "fullDescription": {
+                  "text": "Reports usages of 'kotlin.dom' and 'kotlin.browser' packages. These packages were moved to 'kotlinx.dom' and 'kotlinx.browser' respectively in Kotlin 1.4+.",
+                  "markdown": "Reports usages of `kotlin.dom` and `kotlin.browser` packages.\n\nThese packages were moved to `kotlinx.dom` and `kotlinx.browser`\nrespectively in Kotlin 1.4+."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "ideaSeverity": "ERROR",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Migration",
+                      "index": 118,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CascadeIf",
+                "shortDescription": {
+                  "text": "Cascade if can be replaced with when"
+                },
+                "fullDescription": {
+                  "text": "Reports 'if' statements with three or more branches that can be replaced with the 'when' expression. Example: 'fun checkIdentifier(id: String) {\n      fun Char.isIdentifierStart() = this in 'A'..'z'\n      fun Char.isIdentifierPart() = isIdentifierStart() || this in '0'..'9'\n\n      if (id.isEmpty()) {\n          print(\"Identifier is empty\")\n      } else if (!id.first().isIdentifierStart()) {\n          print(\"Identifier should start with a letter\")\n      } else if (!id.subSequence(1, id.length).all(Char::isIdentifierPart)) {\n          print(\"Identifier should contain only letters and numbers\")\n      }\n  }' A quick-fix converts the 'if' expression to 'when': 'fun checkIdentifier(id: String) {\n      fun Char.isIdentifierStart() = this in 'A'..'z'\n      fun Char.isIdentifierPart() = isIdentifierStart() || this in '0'..'9'\n\n      when {\n          id.isEmpty() -> {\n              print(\"Identifier is empty\")\n          }\n          !id.first().isIdentifierStart() -> {\n              print(\"Identifier should start with a letter\")\n          }\n          !id.subSequence(1, id.length).all(Char::isIdentifierPart) -> {\n              print(\"Identifier should contain only letters and numbers\")\n          }\n      }\n  }'",
+                  "markdown": "Reports `if` statements with three or more branches that can be replaced with the `when` expression.\n\n**Example:**\n\n\n      fun checkIdentifier(id: String) {\n          fun Char.isIdentifierStart() = this in 'A'..'z'\n          fun Char.isIdentifierPart() = isIdentifierStart() || this in '0'..'9'\n\n          if (id.isEmpty()) {\n              print(\"Identifier is empty\")\n          } else if (!id.first().isIdentifierStart()) {\n              print(\"Identifier should start with a letter\")\n          } else if (!id.subSequence(1, id.length).all(Char::isIdentifierPart)) {\n              print(\"Identifier should contain only letters and numbers\")\n          }\n      }\n\nA quick-fix converts the `if` expression to `when`:\n\n\n      fun checkIdentifier(id: String) {\n          fun Char.isIdentifierStart() = this in 'A'..'z'\n          fun Char.isIdentifierPart() = isIdentifierStart() || this in '0'..'9'\n\n          when {\n              id.isEmpty() -> {\n                  print(\"Identifier is empty\")\n              }\n              !id.first().isIdentifierStart() -> {\n                  print(\"Identifier should start with a letter\")\n              }\n              !id.subSequence(1, id.length).all(Char::isIdentifierPart) -> {\n                  print(\"Identifier should contain only letters and numbers\")\n              }\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EmptyRange",
+                "shortDescription": {
+                  "text": "Range with start greater than endInclusive is empty"
+                },
+                "fullDescription": {
+                  "text": "Reports ranges that are empty because the 'start' value is greater than the 'endInclusive' value. Example: 'val range = 2..1' The quick-fix changes the '..' operator to 'downTo': 'val range = 2 downTo 1'",
+                  "markdown": "Reports ranges that are empty because the `start` value is greater than the `endInclusive` value.\n\n**Example:**\n\n\n      val range = 2..1\n\nThe quick-fix changes the `..` operator to `downTo`:\n\n\n      val range = 2 downTo 1\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "OptionalExpectation",
+                "shortDescription": {
+                  "text": "Optionally expected annotation has no actual annotation"
+                },
+                "fullDescription": {
+                  "text": "Reports optionally expected annotations without actual annotation in some platform modules. Example: '// common code\n@OptionalExpectation\nexpect annotation class JvmName(val name: String)\n\n@JvmName(name = \"JvmFoo\")\nfun foo() { }\n\n// jvm code\nactual annotation class JvmName(val name: String)' The inspection also reports cases when 'actual annotation class JvmName' is omitted for non-JVM platforms (for example, Native).",
+                  "markdown": "Reports optionally expected annotations without actual annotation in some platform modules.\n\n**Example:**\n\n    // common code\n    @OptionalExpectation\n    expect annotation class JvmName(val name: String)\n\n    @JvmName(name = \"JvmFoo\")\n    fun foo() { }\n\n    // jvm code\n    actual annotation class JvmName(val name: String)\n\nThe inspection also reports cases when `actual annotation class JvmName` is omitted for non-JVM platforms (for example, Native)."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFORMATION",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "DestructuringWrongName",
+                "shortDescription": {
+                  "text": "Variable in destructuring declaration uses name of a wrong data class property"
+                },
+                "fullDescription": {
+                  "text": "Reports entries of destructuring declarations that match the name of a different property of the destructured data class. Example: 'data class Foo(val a: String, val b: Int, val c: String)\n\n  fun bar(f: Foo) {\n      val (a, c) = f\n  }' The quick-fix changes variable's name to match the name of the corresponding class field: 'data class Foo(val a: String, val b: Int, val c: String)\n\n  fun bar(f: Foo) {\n      val (a, b) = f\n  }'",
+                  "markdown": "Reports entries of destructuring declarations that match the name of a different property of the destructured data class.\n\n**Example:**\n\n\n      data class Foo(val a: String, val b: Int, val c: String)\n\n      fun bar(f: Foo) {\n          val (a, c) = f\n      }\n\nThe quick-fix changes variable's name to match the name of the corresponding class field:\n\n\n      data class Foo(val a: String, val b: Int, val c: String)\n\n      fun bar(f: Foo) {\n          val (a, b) = f\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "IfThenToSafeAccess",
+                "shortDescription": {
+                  "text": "If-Then foldable to '?.'"
+                },
+                "fullDescription": {
+                  "text": "Reports 'if-then' expressions that can be folded into safe-access ('?.') expressions. Example: 'fun bar(x: String) = \"\"\n\n  fun foo(a: String?) {\n     if (a != null) bar(a) else null\n  }' The quick fix converts the 'if-then' expression into a safe-access ('?.') expression: 'fun bar(x: String) = \"\"\n\n  fun foo(a: String?) {\n     a?.let { bar(it) }\n  }'",
+                  "markdown": "Reports `if-then` expressions that can be folded into safe-access (`?.`) expressions.\n\n**Example:**\n\n\n      fun bar(x: String) = \"\"\n\n      fun foo(a: String?) {\n         if (a != null) bar(a) else null\n      }\n\nThe quick fix converts the `if-then` expression into a safe-access (`?.`) expression:\n\n\n      fun bar(x: String) = \"\"\n\n      fun foo(a: String?) {\n         a?.let { bar(it) }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RestrictReturnStatementTargetMigration",
+                "shortDescription": {
+                  "text": "Target label does not denote a function since 1.4"
+                },
+                "fullDescription": {
+                  "text": "Reports labels that don't points to a functions. It's forbidden to declare a target label that does not denote a function. The quick-fix removes the label. Example: 'fun testValLabelInReturn() {\n      L@ val fn = { return@L }\n      fn()\n  }' After the quick-fix is applied: 'fun testValLabelInReturn() {\n      L@ val fn = { return }\n      fn()\n  }' This inspection only reports if the language level of the project or module is 1.4 or higher.",
+                  "markdown": "Reports labels that don't points to a functions.\n\nIt's forbidden to declare a target label that does not denote a function.\n\nThe quick-fix removes the label.\n\n**Example:**\n\n\n      fun testValLabelInReturn() {\n          L@ val fn = { return@L }\n          fn()\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun testValLabelInReturn() {\n          L@ val fn = { return }\n          fn()\n      }\n\nThis inspection only reports if the language level of the project or module is 1.4 or higher."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "ideaSeverity": "ERROR",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Migration",
+                      "index": 118,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "MigrateDiagnosticSuppression",
+                "shortDescription": {
+                  "text": "Diagnostic name should be replaced"
+                },
+                "fullDescription": {
+                  "text": "Reports suppressions with old diagnostic names, for example '@Suppress(\"HEADER_WITHOUT_IMPLEMENTATION\")'. Some of diagnostics from Kotlin 1.2 and earlier are now obsolete, making such suppressions redundant. Example: '@Suppress(\"HEADER_DECLARATION_WITH_BODY\")\nexpect fun connection() {\n  // ...\n}' After the quick-fix is applied: '@Suppress(\"EXPECTED_DECLARATION_WITH_BODY\")\nexpect fun connection() {\n  // ...\n}'",
+                  "markdown": "Reports suppressions with old diagnostic names, for example `@Suppress(\"HEADER_WITHOUT_IMPLEMENTATION\")`.\n\n\nSome of diagnostics from Kotlin 1.2 and earlier are now obsolete, making such suppressions redundant.\n\n**Example:**\n\n\n    @Suppress(\"HEADER_DECLARATION_WITH_BODY\")\n    expect fun connection() {\n      // ...\n    }\n\nAfter the quick-fix is applied:\n\n\n    @Suppress(\"EXPECTED_DECLARATION_WITH_BODY\")\n    expect fun connection() {\n      // ...\n    }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Other problems",
+                      "index": 148,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "DeferredResultUnused",
+                "shortDescription": {
+                  "text": "'@Deferred' result is unused"
+                },
+                "fullDescription": {
+                  "text": "Reports function calls with the 'Deferred' result type if the return value is not used. If the 'Deferred' return value is not used, the call site would not wait to complete this function. Example: 'fun calcEverythingAsync() = CompletableDeferred(42)\n\n  fun usage() {\n      calcEverythingAsync()\n  }' A quick-fix provides a variable with the 'Deferred' initializer: 'fun calcEverythingAsync() = CompletableDeferred(42)\n\n  fun usage() {\n      val answer = calcEverythingAsync()\n  }'",
+                  "markdown": "Reports function calls with the `Deferred` result type if the return value is not used.\n\nIf the `Deferred` return value is not used, the call site would not wait to complete this function.\n\n**Example:**\n\n\n      fun calcEverythingAsync() = CompletableDeferred(42)\n\n      fun usage() {\n          calcEverythingAsync()\n      }\n\nA quick-fix provides a variable with the `Deferred` initializer:\n\n\n      fun calcEverythingAsync() = CompletableDeferred(42)\n\n      fun usage() {\n          val answer = calcEverythingAsync()\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SelfReferenceConstructorParameter",
+                "shortDescription": {
+                  "text": "Constructor can never be complete"
+                },
+                "fullDescription": {
+                  "text": "Reports constructors with a non-null self-reference parameter. Such constructors never instantiate a class. The quick-fix converts the parameter type to nullable. Example: 'class SelfRef(val ref: SelfRef)' After the quick-fix is applied: 'class SelfRef(val ref: SelfRef?)'",
+                  "markdown": "Reports constructors with a non-null self-reference parameter.\n\nSuch constructors never instantiate a class.\n\nThe quick-fix converts the parameter type to nullable.\n\n**Example:**\n\n\n      class SelfRef(val ref: SelfRef)\n\nAfter the quick-fix is applied:\n\n\n      class SelfRef(val ref: SelfRef?)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "MainFunctionReturnUnit",
+                "shortDescription": {
+                  "text": "Entry point function should return Unit"
+                },
+                "fullDescription": {
+                  "text": "Reports entry point functions with an incorrect return type (should be 'Unit'). Example: 'fun main() = \"Hello world!\"'",
+                  "markdown": "Reports entry point functions with an incorrect return type (should be `Unit`).\n\n**Example:**\n`fun main() = \"Hello world!\"`"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "SuspiciousCallableReferenceInLambda",
+                "shortDescription": {
+                  "text": "Suspicious callable reference used as lambda result"
+                },
+                "fullDescription": {
+                  "text": "Reports lambda expressions with one callable reference. It is a common error to replace a lambda with a callable reference without changing curly braces to parentheses. Example: 'listOf(1,2,3).map { it::toString }' After the quick-fix is applied: 'listOf(1,2,3).map(Int::toString)'",
+                  "markdown": "Reports lambda expressions with one callable reference.\n\nIt is a common error to replace a lambda with a callable reference without changing curly braces to parentheses.\n\n**Example:**\n\n      listOf(1,2,3).map { it::toString }\n\nAfter the quick-fix is applied:\n\n      listOf(1,2,3).map(Int::toString)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ConvertSecondaryConstructorToPrimary",
+                "shortDescription": {
+                  "text": "Convert to primary constructor"
+                },
+                "fullDescription": {
+                  "text": "Reports a secondary constructor that can be replaced with a more concise primary constructor. Example: 'class User {\n      val name: String\n\n      constructor(name: String) {\n          this.name = name\n      }\n  }' A quick-fix converts code automatically: 'class User(val name: String) {\n  }'",
+                  "markdown": "Reports a secondary constructor that can be replaced with a more concise primary constructor.\n\n**Example:**\n\n\n      class User {\n          val name: String\n\n          constructor(name: String) {\n              this.name = name\n          }\n      }\n\nA quick-fix converts code automatically:\n\n\n      class User(val name: String) {\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceGetOrSet",
+                "shortDescription": {
+                  "text": "Explicit 'get' or 'set' call"
+                },
+                "fullDescription": {
+                  "text": "Reports explicit calls to 'get' or 'set' functions which can be replaced by an indexing operator '[]'. Kotlin allows custom implementations for the predefined set of operators on types. To overload an operator, you can mark the corresponding function with the 'operator' modifier: 'operator fun get(index: Int) {}\n  operator fun set(index: Int, value: Int) {}' The functions above correspond to the indexing operator. Example: 'class Test {\n      operator fun get(i: Int): Int = 0\n  }\n\n  fun test() {\n      Test().get(0) // replaceable 'get()'\n  }' After the quick-fix is applied: 'class Test {\n      operator fun get(i: Int): Int = 0\n  }\n\n  fun test() {\n      Test()[0]\n  }'",
+                  "markdown": "Reports explicit calls to `get` or `set` functions which can be replaced by an indexing operator `[]`.\n\n\nKotlin allows custom implementations for the predefined set of operators on types.\nTo overload an operator, you can mark the corresponding function with the `operator` modifier:\n\n\n      operator fun get(index: Int) {}\n      operator fun set(index: Int, value: Int) {}\n        \nThe functions above correspond to the indexing operator.\n\n**Example:**\n\n      class Test {\n          operator fun get(i: Int): Int = 0\n      }\n\n      fun test() {\n          Test().get(0) // replaceable 'get()'\n      }\n\nAfter the quick-fix is applied:\n\n      class Test {\n          operator fun get(i: Int): Int = 0\n      }\n\n      fun test() {\n          Test()[0]\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ProhibitRepeatedUseSiteTargetAnnotationsMigration",
+                "shortDescription": {
+                  "text": "Repeated annotation which is not marked as '@Repeatable'"
+                },
+                "fullDescription": {
+                  "text": "Reports the repeated use of a non-'@Repeatable' annotation on property accessors. As a result of using non-'@Repeatable' annotation multiple times, both annotation usages will appear in the bytecode leading to an ambiguity in reflection calls. Since Kotlin 1.4 it's mandatory to either mark annotation as '@Repeatable' or not repeat the annotation, otherwise it will lead to compilation error. Example: 'annotation class Foo(val x: Int)\n\n  @get:Foo(10)\n  val a: String\n      @Foo(20) get() = \"foo\" // annotation repeated twice but not marked as @Repeatable' This inspection only reports if the Kotlin language level of the project or module is 1.4 or higher.",
+                  "markdown": "Reports the repeated use of a non-`@Repeatable` annotation on property accessors.\n\n\nAs a result of using non-`@Repeatable` annotation multiple times, both annotation usages\nwill appear in the bytecode leading to an ambiguity in reflection calls.\n\n\nSince Kotlin 1.4 it's mandatory to either mark annotation as `@Repeatable` or not\nrepeat the annotation, otherwise it will lead to compilation error.\n\n**Example:**\n\n\n      annotation class Foo(val x: Int)\n\n      @get:Foo(10)\n      val a: String\n          @Foo(20) get() = \"foo\" // annotation repeated twice but not marked as @Repeatable\n\nThis inspection only reports if the Kotlin language level of the project or module is 1.4 or higher."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "ideaSeverity": "ERROR",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Migration",
+                      "index": 118,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "Destructure",
+                "shortDescription": {
+                  "text": "Use destructuring declaration"
+                },
+                "fullDescription": {
+                  "text": "Reports declarations that can be destructured. Example: 'data class My(val first: String, val second: Int, val third: Boolean)\n\n  fun foo(list: List<My>) {\n      list.forEach { my ->\n          println(my.second)\n          println(my.third)\n      }\n  }' The quick-fix destructures the declaration and introduces new variables with names from the corresponding class: 'data class My(val first: String, val second: Int, val third: Boolean)\n\n  fun foo(list: List<My>) {\n      list.forEach { (_, second, third) ->\n          println(second)\n          println(third)\n      }\n  }'",
+                  "markdown": "Reports declarations that can be destructured.\n\n**Example:**\n\n\n      data class My(val first: String, val second: Int, val third: Boolean)\n\n      fun foo(list: List<My>) {\n          list.forEach { my ->\n              println(my.second)\n              println(my.third)\n          }\n      }\n\nThe quick-fix destructures the declaration and introduces new variables with names from the corresponding class:\n\n\n      data class My(val first: String, val second: Int, val third: Boolean)\n\n      fun foo(list: List<My>) {\n          list.forEach { (_, second, third) ->\n              println(second)\n              println(third)\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "INFO",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UnusedReceiverParameter",
+                "shortDescription": {
+                  "text": "Unused receiver parameter"
+                },
+                "fullDescription": {
+                  "text": "Reports receiver parameter of extension functions and properties that is not used. Remove redundant receiver parameter can be used to amend the code automatically.",
+                  "markdown": "Reports receiver parameter of extension functions and properties that is not used.\n\n**Remove redundant receiver parameter** can be used to amend the code automatically."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ConvertTryFinallyToUseCall",
+                "shortDescription": {
+                  "text": "Convert try / finally to use() call"
+                },
+                "fullDescription": {
+                  "text": "Reports a 'try-finally' block with 'resource.close()' in 'finally' which can be converted to a 'resource.use()' call. 'use()' is easier to read and less error-prone as there is no need in explicit 'close()' call. Example: 'fun example() {\n      val reader = File(\"file.txt\").bufferedReader()\n      try {\n          reader.lineSequence().forEach(::print)\n      } finally {\n          reader.close()\n      }\n  }' After the quick-fix applied: 'fun example() {\n      File(\"file.txt\").bufferedReader().use { reader ->\n          reader.lineSequence().forEach(::print)\n      }\n  }'",
+                  "markdown": "Reports a `try-finally` block with `resource.close()` in `finally` which can be converted to a `resource.use()` call.\n\n`use()` is easier to read and less error-prone as there is no need in explicit `close()` call.\n\n**Example:**\n\n\n      fun example() {\n          val reader = File(\"file.txt\").bufferedReader()\n          try {\n              reader.lineSequence().forEach(::print)\n          } finally {\n              reader.close()\n          }\n      }\n\nAfter the quick-fix applied:\n\n\n      fun example() {\n          File(\"file.txt\").bufferedReader().use { reader ->\n              reader.lineSequence().forEach(::print)\n          }\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "KotlinRedundantOverride",
+                "shortDescription": {
+                  "text": "Redundant overriding method"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant overriding declarations. An override can be omitted if it does not modify the inherited signature semantics, for example, by changing visibility. Example: 'open class Foo {\n      open fun singleExpression() {\n      }\n  }\n\n  class Bar : Foo() {\n      override fun singleExpression() = super.singleExpression()\n  }' After the quick-fix is applied: 'class Bar : Foo() {\n  }'",
+                  "markdown": "Reports redundant overriding declarations.\n\n\nAn override can be omitted if it does not modify the inherited signature semantics, for example, by changing visibility.\n\n**Example:**\n\n\n      open class Foo {\n          open fun singleExpression() {\n          }\n      }\n\n      class Bar : Foo() {\n          override fun singleExpression() = super.singleExpression()\n      }\n\nAfter the quick-fix is applied:\n\n\n      class Bar : Foo() {\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceArrayOfWithLiteral",
+                "shortDescription": {
+                  "text": "'arrayOf' call can be replaced with array literal [...]"
+                },
+                "fullDescription": {
+                  "text": "Reports 'arrayOf' calls that can be replaced with array literals '[...]'. Examples: 'annotation class MyAnnotation(val strings: Array<String>)\n\n  @MyAnnotation(arrayOf(\"alpha\", \"beta\", \"omega\")) // replaceable 'arrayOf()'\n  class MyClass' After the quick-fix is applied: 'annotation class MyAnnotation(val strings: Array<String>)\n\n  @MyAnnotation([\"alpha\", \"beta\", \"omega\"])\n  class MyClass'",
+                  "markdown": "Reports `arrayOf` calls that can be replaced with array literals `[...]`.\n\n**Examples:**\n\n      annotation class MyAnnotation(val strings: Array<String>)\n\n      @MyAnnotation(arrayOf(\"alpha\", \"beta\", \"omega\")) // replaceable 'arrayOf()'\n      class MyClass\n\nAfter the quick-fix is applied:\n\n      annotation class MyAnnotation(val strings: Array<String>)\n\n      @MyAnnotation([\"alpha\", \"beta\", \"omega\"])\n      class MyClass\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ReplaceToWithInfixForm",
+                "shortDescription": {
+                  "text": "'to' call should be replaced with infix form"
+                },
+                "fullDescription": {
+                  "text": "Reports 'to' function calls that can be replaced with the infix form. Using the infix form makes your code simpler. The quick-fix replaces 'to' with the infix form. Example: 'fun foo(a: Int, b: Int) {\n      val pair = a.to(b)\n  }' After the quick-fix is applied: 'fun foo(a: Int, b: Int) {\n      val pair = a to b\n  }'",
+                  "markdown": "Reports `to` function calls that can be replaced with the infix form.\n\nUsing the infix form makes your code simpler.\n\nThe quick-fix replaces `to` with the infix form.\n\n**Example:**\n\n\n      fun foo(a: Int, b: Int) {\n          val pair = a.to(b)\n      }\n\nAfter the quick-fix is applied:\n\n\n      fun foo(a: Int, b: Int) {\n          val pair = a to b\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Style issues",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ConstPropertyName",
+                "shortDescription": {
+                  "text": "Const property naming convention"
+                },
+                "fullDescription": {
+                  "text": "Reports 'const' property names that do not follow the recommended naming conventions. Consistent naming allows for easier code reading and understanding. According to the Kotlin official style guide, 'const' properties should use uppercase underscore-separated names. Example: 'const val Planck: Double = 6.62607015E-34' A quick-fix renames the property: 'const val PLANCK: Double = 6.62607015E-34'",
+                  "markdown": "Reports `const` property names that do not follow the recommended naming conventions.\n\n\nConsistent naming allows for easier code reading and understanding.\nAccording to the [Kotlin official style guide](https://kotlinlang.org/docs/coding-conventions.html#property-names),\n`const` properties should use uppercase underscore-separated names.\n\n**Example:**\n\n\n      const val Planck: Double = 6.62607015E-34\n\nA quick-fix renames the property:\n\n\n      const val PLANCK: Double = 6.62607015E-34\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "ideaSeverity": "WEAK WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Naming conventions",
+                      "index": 47,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RedundantNullableReturnType",
+                "shortDescription": {
+                  "text": "Redundant nullable return type"
+                },
+                "fullDescription": {
+                  "text": "Reports functions and variables with nullable return type which never return or become 'null'. Example: 'fun greeting(user: String): String? = \"Hello, $user!\"' After the quick-fix is applied: 'fun greeting(user: String): String = \"Hello, $user!\"'",
+                  "markdown": "Reports functions and variables with nullable return type which never return or become `null`.\n\n**Example:**\n\n\n      fun greeting(user: String): String? = \"Hello, $user!\"\n\nAfter the quick-fix is applied:\n\n\n      fun greeting(user: String): String = \"Hello, $user!\"\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Redundant constructs",
+                      "index": 4,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UselessCallOnNotNull",
+                "shortDescription": {
+                  "text": "Useless call on not-null type"
+                },
+                "fullDescription": {
+                  "text": "Reports calls on not-null receiver that make sense only for nullable receiver. Several functions from the standard library such as 'orEmpty()' or 'isNullOrEmpty' have sense only when they are called on receivers of nullable types. Otherwise, they can be omitted or simplified as the result will be the same. Remove redundant call and Change call to … quick-fixes can be used to amend the code automatically. Examples: 'fun test(s: String) {\n      val x = s.orEmpty() // quick-fix simplifies to 's'\n      val y = s.isNullOrEmpty() // quick-fix simplifies to 's.isEmpty()'\n  }'",
+                  "markdown": "Reports calls on not-null receiver that make sense only for nullable receiver.\n\nSeveral functions from the standard library such as `orEmpty()` or `isNullOrEmpty`\nhave sense only when they are called on receivers of nullable types. Otherwise, they can be omitted or simplified as the result will be the same.\n\n**Remove redundant call** and **Change call to ...** quick-fixes can be used to amend the code automatically.\n\nExamples:\n\n\n      fun test(s: String) {\n          val x = s.orEmpty() // quick-fix simplifies to 's'\n          val y = s.isNullOrEmpty() // quick-fix simplifies to 's.isEmpty()'\n      }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RiderSolutionErrorsInspection",
+                "shortDescription": {
+                  "text": "Rider toolset and environment errors"
+                },
+                "fullDescription": {
+                  "text": "Reports toolset and environment errors detected by Rider.",
+                  "markdown": "Reports toolset and environment errors detected by Rider."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "RiderSolutionErrorsInspection",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Rider/General",
+                      "index": 134,
+                      "toolComponent": {
+                        "name": "QDNET"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EqualsOrHashCode",
+                "shortDescription": {
+                  "text": "'equals()' and 'hashCode()' not paired"
+                },
+                "fullDescription": {
+                  "text": "Reports classes that override 'equals()' but do not override 'hashCode()', or vice versa. It also reports object declarations that override either 'equals()' or 'hashCode()'. This can lead to undesired behavior when a class is added to a 'Collection' Example: 'class C1 {\n      override fun equals(other: Any?) = true\n  }\n\n  class C2 {\n      override fun hashCode() = 0\n  }\n\n  object O1 {\n      override fun equals(other: Any?) = true\n  }\n\n  object O2 {\n      override fun hashCode() = 0\n  }' The quick-fix overrides 'equals()' or 'hashCode()' for classes and deletes these methods for objects: 'class C1 {\n       override fun equals(other: Any?) = true\n       override fun hashCode(): Int {\n           return javaClass.hashCode()\n       }\n   }\n\n   class C2 {\n       override fun hashCode() = 0\n       override fun equals(other: Any?): Boolean {\n           if (this === other) return true\n           if (javaClass != other?.javaClass) return false\n           return true\n       }\n   }\n\n   object O1 {\n   }\n\n   object O2 {\n   }'",
+                  "markdown": "Reports classes that override `equals()` but do not override `hashCode()`, or vice versa. It also reports object declarations that override either `equals()` or `hashCode()`.\n\nThis can lead to undesired behavior when a class is added to a `Collection`\n\n**Example:**\n\n\n      class C1 {\n          override fun equals(other: Any?) = true\n      }\n\n      class C2 {\n          override fun hashCode() = 0\n      }\n\n      object O1 {\n          override fun equals(other: Any?) = true\n      }\n\n      object O2 {\n          override fun hashCode() = 0\n      }\n\nThe quick-fix overrides `equals()` or `hashCode()` for classes and deletes these methods for objects:\n\n\n       class C1 {\n           override fun equals(other: Any?) = true\n           override fun hashCode(): Int {\n               return javaClass.hashCode()\n           }\n       }\n\n       class C2 {\n           override fun hashCode() = 0\n           override fun equals(other: Any?): Boolean {\n               if (this === other) return true\n               if (javaClass != other?.javaClass) return false\n               return true\n           }\n       }\n\n       object O1 {\n       }\n\n       object O2 {\n       }\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "ideaSeverity": "WARNING",
+                    "tags": [
+                      "ideaSeverity"
+                    ]
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Kotlin/Probable bugs",
+                      "index": 24,
+                      "toolComponent": {
+                        "name": "QDJVM"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          }
+        ]
+      },
+      "invocations": [
+        {
+          "exitCode": 0,
+          "toolExecutionNotifications": [],
+          "executionSuccessful": true
+        }
+      ],
+      "language": "en-US",
+      "results": [
+        {
+          "ruleId": "ControlFlowWithEmptyBody",
+          "kind": "fail",
+          "level": "error",
+          "message": {
+            "text": "'while' has empty body",
+            "markdown": "'while' has empty body"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "dokker/src/main/kotlin/io/github/tiulpin/Dokker.kt",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 271,
+                  "startColumn": 5,
+                  "charOffset": 6917,
+                  "charLength": 5,
+                  "snippet": {
+                    "text": "while"
+                  },
+                  "sourceLanguage": "kotlin"
+                },
+                "contextRegion": {
+                  "startLine": 269,
+                  "startColumn": 1,
+                  "charOffset": 6885,
+                  "charLength": 71,
+                  "snippet": {
+                    "text": "        println(null)\n    }\n    while (false) {\n    }\n    if (update) {"
+                  }
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "dokker.dokker.main",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v1": "f0b3b16328b5e11f45afdc0ae3fe79aa989b8909330a81d810ae499b347aca32"
+          },
+          "baselineState": "new",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "tags": [
+              "ideaSeverity"
+            ]
+          }
+        },
+        {
+          "ruleId": "ConstantConditionIf",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Condition is always 'true'",
+            "markdown": "Condition is always 'true'"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "dokker/src/main/kotlin/io/github/tiulpin/Dokker.kt",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 268,
+                  "startColumn": 9,
+                  "charOffset": 6877,
+                  "charLength": 4,
+                  "snippet": {
+                    "text": "true"
+                  },
+                  "sourceLanguage": "kotlin"
+                },
+                "contextRegion": {
+                  "startLine": 266,
+                  "startColumn": 1,
+                  "charOffset": 6685,
+                  "charLength": 227,
+                  "snippet": {
+                    "text": "    val installPackages = packages.joinToString(INSTALL_SEP)\n    var command = \"DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $INSTALL_SEP$installPackages\"\n    if (true) {\n        println(null)\n    }"
+                  }
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "dokker.dokker.main",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v1": "eba2d761291ee6bda42bf3ff0a3856509e0140a940f297ba99450b51d0f7905e"
+          },
+          "baselineState": "new",
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "tags": [
+              "ideaSeverity"
+            ]
+          }
+        },
+        {
+          "ruleId": "RiderSolutionErrorsInspection",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "[NU1101] Unable to find package PrivatePackage. No packages exist with this id in source(s): github at (0:0) Target: ResolvePackageAssets Task: ResolvePackageAssets",
+            "markdown": "\\[[NU1101](http://www.google.com/search?q=NU1101)\\] Unable to find package PrivatePackage. No packages exist with this id in source(s): github at (0:0)  \n\nTarget: ResolvePackageAssets  \nTask: ResolvePackageAssets"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "LibraryReferencingPackage/LibraryReferencingPackage.csproj",
+                  "uriBaseId": "SRCROOT"
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v1": "2eb5998cec5651ad1ad36262cf210caa653ab138d3c22e4338d3eea704104bf6"
+          },
+          "baselineState": "new",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High"
+          }
+        },
+        {
+          "ruleId": "MayBeConstant",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Might be 'const'",
+            "markdown": "Might be 'const'"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "dokker/src/main/kotlin/io/github/tiulpin/Dokker.kt",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 283,
+                  "startColumn": 5,
+                  "charOffset": 7206,
+                  "charLength": 4,
+                  "snippet": {
+                    "text": "help"
+                  },
+                  "sourceLanguage": "kotlin"
+                },
+                "contextRegion": {
+                  "startLine": 281,
+                  "startColumn": 1,
+                  "charOffset": 7199,
+                  "charLength": 17,
+                  "snippet": {
+                    "text": "}\n\nval help = \"\"\n"
+                  }
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "dokker.dokker.main",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v1": "54ac5fc68d708d7ae0f4fc0732dc3173126a76a86ec9f429bd133a5fb9a8f8fa"
+          },
+          "baselineState": "new",
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "tags": [
+              "ideaSeverity"
+            ]
+          }
+        },
+        {
+          "ruleId": "ConstantConditionIf",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Condition is always 'true'",
+            "markdown": "Condition is always 'true'"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "dokker/src/main/kotlin/io/github/tiulpin/Dokker.kt",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 269,
+                  "startColumn": 11,
+                  "charOffset": 6911,
+                  "charLength": 4,
+                  "snippet": {
+                    "text": "true"
+                  },
+                  "sourceLanguage": "kotlin"
+                },
+                "contextRegion": {
+                  "startLine": 269,
+                  "startColumn": 11,
+                  "charOffset": 6911,
+                  "charLength": 38,
+                  "snippet": {
+                    "text": "if (true) {\n        println(null)\n    }"
+                  }
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "dokker.dokker.main",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v1": "eba2d761291ee6bda42bf3ff0a3856000e0140a940f297ba99450b51d0f7905e"
+          },
+          "baselineState": "absent",
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "tags": [
+              "ideaSeverity"
+            ]
+          }
+        },
+        {
+          "ruleId": "ConstantConditionIf",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Condition is always 'true'",
+            "markdown": "Condition is always 'true'"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "dokker/src/main/kotlin/io/github/tiulpin/Dokker.kt",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 270,
+                  "startColumn": 13,
+                  "charOffset": 6943,
+                  "charLength": 4,
+                  "snippet": {
+                    "text": "true"
+                  },
+                  "sourceLanguage": "kotlin"
+                },
+                "contextRegion": {
+                  "startLine": 270,
+                  "startColumn": 13,
+                  "charOffset": 6943,
+                  "charLength": 38,
+                  "snippet": {
+                    "text": "if (true) {\n        println(null)\n    }"
+                  }
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "dokker.dokker.main",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v1": "eba2d761291ab4bda42bf3ff0a3856000e0140a940f297ba99450b51d0f7905e"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "tags": [
+              "ideaSeverity"
+            ]
+          }
+        }
+      ],
+      "automationDetails": {
+        "id": "project - 12/13/21, 3:48 PM",
+        "guid": "d0a57b70-6936-41ab-bf04-97c58449a43d"
+      },
+      "newlineSequences": [
+        "\r\n",
+        "\n"
+      ],
+      "properties": {
+        "qodanaFailureConditions": {
+          "testCoverageThresholds": {
+            "totalCoverage": 40,
+            "freshCoverage": 40
+          }
+        },
+        "coverage": {
+          "totalCoverage": 45.0,
+          "totalLines": 124.0,
+          "totalCoveredLines": 56.0
+        }
+      }
+    }
+  ]
+}

--- a/scan/__tests__/main.test.ts
+++ b/scan/__tests__/main.test.ts
@@ -65,6 +65,12 @@ test('test sarif with problems to output annotations', () => {
   expect(result.annotations).toEqual(output)
 })
 
+test('test sarif with problems and baseline to output annotations', () => {
+  const output = annotationsDefaultFixture()
+  const result = parseSarif('__tests__/data/with.baseline.sarif.json')
+  expect(result.annotations).toEqual(output)
+})
+
 test('test sarif with no problems to output annotations', () => {
   const output = outputEmptyFixture()
   const result = parseSarif('__tests__/data/empty.sarif.json')

--- a/scan/src/annotations.ts
+++ b/scan/src/annotations.ts
@@ -204,7 +204,11 @@ export function parseSarif(path: string): Output {
       run.results.length
     )} found by `
     annotations = run.results
-      .filter(result => result.baselineState !== 'unchanged')
+      .filter(
+        result =>
+          result.baselineState !== 'unchanged' &&
+          result.baselineState !== 'absent'
+      )
       .map(result => parseResult(result, rules))
       .filter((a): a is Annotation => a !== null && a !== undefined)
   }

--- a/vsts/vss-extension.dev.json
+++ b/vsts/vss-extension.dev.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "qodana-dev",
   "name": "Qodana (Dev)",
-  "version": "2024.3.152",
+  "version": "2024.3.154",
   "publisher": "JetBrains",
   "targets": [
     {


### PR DESCRIPTION

This pull request includes several changes to improve the handling of SARIF files and update versioning information. The most important changes include adding new test cases, updating the SARIF parsing logic, and updating the version in the manifest file.

### Improvements to SARIF handling:

* [`scan/__tests__/main.test.ts`](diffhunk://#diff-73fba351e685551c0c657ca9bb8ba5a06078284e545d00391e2cd194959b32e2R68-R73): Added a new test case to check the output annotations for SARIF files with problems and a baseline.
* [`scan/src/annotations.ts`](diffhunk://#diff-c46644b93412fc9935e88b95236a07beffd8d1cb81d5cb745c42d28113411661L207-R211): Updated the `parseSarif` function to filter out results with a baseline state of 'absent' in addition to 'unchanged'.

### Versioning update:

* [`vsts/vss-extension.dev.json`](diffhunk://#diff-de571600ac435f9986a11800b6d21b473f3752aea5e727c5701d9748c9f8bda7L5-R5): Updated the version from `2024.3.152` to `2024.3.154`.