### PR TITLE
Take into account analyzed directory then displaying output

### DIFF
--- a/scan/__tests__/main.test.ts
+++ b/scan/__tests__/main.test.ts
@@ -81,6 +81,7 @@ test('test typical summary output', () => {
   const result = getSummary(
     'Qodana for JS',
     'frontend',
+    'web',
     annotationsDefaultFixture().reverse(), // reversed for testing the correct sorting in output
     '',
     0,
@@ -94,6 +95,7 @@ test('test typical summary output', () => {
 test('test empty summary output', () => {
   const result = getSummary(
     'Qodana for JS',
+    '',
     '',
     outputEmptyFixture(),
     '',
@@ -289,7 +291,8 @@ export function defaultDockerRunCommandFixture(): string[] {
 
 export function markdownSummaryFixture(): string {
   return `# [Qodana](https://example.com/report) for JS
-\`frontend/\`
+Analyzed project: \`frontend/\`
+Analyzed directory: \`web/\`
 
 **4 new problems** were found
 

--- a/scan/src/main.ts
+++ b/scan/src/main.ts
@@ -96,6 +96,7 @@ async function main(): Promise<void> {
       publishOutput(
         exitCode === QodanaExitCode.FailThreshold,
         extractArg('-i', '--project-dir', inputs.args),
+        extractArg('-d', '--source-directory', inputs.args),
         inputs.resultsDir,
         inputs.useAnnotations,
         inputs.postComment,

--- a/scan/src/utils.ts
+++ b/scan/src/utils.ts
@@ -392,11 +392,13 @@ export function getWorkflowRunUrl(): string {
  * Post a new comment to the pull request.
  * @param toolName The name of the tool to mention in comment.
  * @param content The comment to post.
+ * @param sourceDir The analyzed directory inside project
  * @param postComment Whether to post a comment or not.
  */
 export async function postResultsToPRComments(
   toolName: string,
   content: string,
+  sourceDir: string,
   postComment: boolean
 ): Promise<void> {
   const pr = github.context.payload.pull_request as
@@ -405,7 +407,8 @@ export async function postResultsToPRComments(
   if (!postComment || !pr) {
     return
   }
-  const comment_tag_pattern = `<!-- JetBrains/qodana-action@v${VERSION} : ${toolName} -->`
+  // source dir needed in case of monorepo with projects analyzed by the same tool
+  const comment_tag_pattern = `<!-- JetBrains/qodana-action@v${VERSION} : ${toolName}, ${sourceDir} -->`
   const body = `${content}\n${comment_tag_pattern}`
   const client = github.getOctokit(getInputs().githubToken)
   const comment_id = await findCommentByTag(client, comment_tag_pattern)

--- a/vsts/vss-extension.dev.json
+++ b/vsts/vss-extension.dev.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "qodana-dev",
   "name": "Qodana (Dev)",
-  "version": "2024.3.154",
+  "version": "2024.3.155",
   "publisher": "JetBrains",
   "targets": [
     {


### PR DESCRIPTION
In monorepo if two projects use the same linter the result comment of one will override the other. This pull request fixes the issue