### PR TITLE
:bug: QD-10901 Fix built-in gha summary override in monorepo

### DIFF
--- a/scan/src/output.ts
+++ b/scan/src/output.ts
@@ -115,7 +115,8 @@ export async function publishOutput(
       DEPENDENCY_CHARS_LIMIT,
       VIEW_REPORT_OPTIONS
     )
-
+    // source dir is needed for project distinction in monorepo
+    const jobName = `${toolName}` + (sourceDir === '' ? '' : ` (${sourceDir})`)
     await Promise.all([
       putReaction(ANALYSIS_FINISHED_REACTION, ANALYSIS_STARTED_REACTION),
       postResultsToPRComments(
@@ -125,7 +126,7 @@ export async function publishOutput(
         postComment
       ),
       core.summary.addRaw(problems.summary).write(),
-      publishAnnotations(toolName, problems, failedByThreshold, useAnnotations)
+      publishAnnotations(jobName, problems, failedByThreshold, useAnnotations)
     ])
   } catch (error) {
     core.warning(

--- a/vsts/vss-extension.dev.json
+++ b/vsts/vss-extension.dev.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "qodana-dev",
   "name": "Qodana (Dev)",
-  "version": "2024.3.192",
+  "version": "2024.3.194",
   "publisher": "JetBrains",
   "targets": [
     {


### PR DESCRIPTION
GHA uses name provided in the "publishAnnotations" as job summary identifier, which may lead to summary overriding in monorepo. This PR fixes this by incorporating source dir into name