### PR TITLE
:bricks: Configure workflow permissions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,6 +17,11 @@ on:
       - 'plugin/**'
       - 'common/src/**'
       - 'common/build.gradle.kts'
+
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   gradleValidation:
     name: gradle-wrapper

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -27,6 +27,12 @@ on:
       - 'gradlew'
       - 'gradlew.bat'
       - '.github/workflows/gradle.yml'
+
+permissions:
+  contents: write
+  pull-requests: read
+  statuses: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates GitHub workflow configuration files to include permissions sections, specifying access levels for contents, packages, pull requests, and statuses.

### Workflow configuration updates:

* [`.github/workflows/gradle.yml`](diffhunk://#diff-0d634959c8276ae976e39ba475e63d0b9ec27824470c79f1971f58fe37c46325R20-R25): Added a `permissions` section granting `contents: read` and `packages: read` access.
* [`.github/workflows/node.yml`](diffhunk://#diff-4e88a8cc63d2540befa3412886ac9b9db5cd10bce852960298517ea4bd7f7bb7R30-R36): Added a `permissions` section granting `contents: write`, `pull-requests: read`, and `statuses: write` access.