### PR TITLE
:bug: QD-14507 Fix undefined release name in notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,8 @@ jobs:
           fetch-depth: 0
       - run: |
           ./changelog.sh > changelog.md
-          gh release create ${GITHUB_REF##*/} -F changelog.md
+          TAG_NAME=${GITHUB_REF##*/}
+          gh release create $TAG_NAME --title "$TAG_NAME" -F changelog.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   azure:


### PR DESCRIPTION
## Summary
Fixes QD-14507: GitHub release notifications show "Release - undefined" because the `gh release create` command was missing the `--title` parameter.

## Changes
- Added `--title` parameter to `gh release create` command in `.github/workflows/release.yml`
- Now the release name will properly show as the tag name instead of "undefined"

## Testing
- The fix will be validated on the next release
- Expected: Release notifications will show "Release - v2026.1.x" instead of "Release - undefined"

## Links
- Issue: https://youtrack.jetbrains.com/issue/QD-14507