### PR TITLE
:bug: QD-14658 Fix Maven integration test with reliable Python issue detection

### DIFF
--- a/maven/src/test/kotlin/org/jetbrains/qodana/maven/QodanaScanMojoIntegrationTest.kt
+++ b/maven/src/test/kotlin/org/jetbrains/qodana/maven/QodanaScanMojoIntegrationTest.kt
@@ -96,8 +96,8 @@ class QodanaScanMojoIntegrationTest {
             assumeTrue(isLinux, "Docker tests only run on Linux in GitHub Actions")
         }
 
-        // Create a Python file with issues (extra blank lines)
-        File(projectDir, "main.py").writeText("print('Hello, world!')\n\n\n\n\n\nprint()")
+        // Create a Python file with issues (syntax error)
+        File(projectDir, "main.py").writeText("def broken_function(\n    print(\"syntax error\")")
         File(projectDir, "qodana.yaml").writeText("linter: jetbrains/qodana-python-community")
 
         val result = runMaven(

--- a/vsts/QodanaScan/index.js
+++ b/vsts/QodanaScan/index.js
@@ -81735,7 +81735,7 @@ var require_utils4 = __commonJS({
         uploadResult: tl2.getBoolInput("uploadResult", false),
         uploadSarif: tl2.getBoolInput("uploadSarif", false),
         artifactName: tl2.getInput("artifactName", false) || "qodana-report",
-        useNightly: tl2.getBoolInput("useNightly", false),
+        nightlyVersion: tl2.getInput("nightlyVersion", false) || "",
         prMode: tl2.getBoolInput("prMode", false),
         postComment: tl2.getBoolInput("postPrComment", false),
         pushFixes: tl2.getInput("pushFixes", false) || "none",
@@ -81775,11 +81775,12 @@ var require_utils4 = __commonJS({
       });
     }
     function prepareAgent(args_1) {
-      return __awaiter2(this, arguments, void 0, function* (args, useNightly = false) {
+      return __awaiter2(this, arguments, void 0, function* (args, nightlyVersion = "") {
         const arch = (0, qodana_12.getProcessArchName)();
         const platform = (0, qodana_12.getProcessPlatformName)();
-        const temp = yield tool.downloadTool((0, qodana_12.getQodanaUrl)(arch, platform, useNightly));
-        if (!useNightly) {
+        const nightlyTag = yield (0, qodana_12.getNightlyTag)(nightlyVersion);
+        const temp = yield tool.downloadTool((0, qodana_12.getQodanaUrl)(arch, platform, nightlyTag));
+        if (!nightlyVersion) {
           const expectedChecksum = (0, qodana_12.getQodanaSha256)(arch, platform);
           const actualChecksum = (0, qodana_12.sha256sum)(temp);
           if (expectedChecksum !== actualChecksum) {
@@ -82169,7 +82170,7 @@ function main() {
       const inputs = (0, utils_1.getInputs)();
       tl.mkdirP(inputs.resultsDir);
       tl.mkdirP(inputs.cacheDir);
-      yield (0, utils_1.prepareAgent)(inputs.args, inputs.useNightly);
+      yield (0, utils_1.prepareAgent)(inputs.args, inputs.nightlyVersion);
       const exitCode = yield (0, utils_1.qodana)();
       yield Promise.all([
         (0, utils_1.pushQuickFixes)(inputs.pushFixes, inputs.commitMessage),

--- a/vsts/vss-extension.dev.json
+++ b/vsts/vss-extension.dev.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "qodana-dev",
   "name": "Qodana (Dev)",
-  "version": "2026.1.44",
+  "version": "2026.1.45",
   "publisher": "JetBrains",
   "targets": [
     {


### PR DESCRIPTION
## Problem
Maven plugin integration test `run qodana in a container in a non-empty directory and fail with threshold` was failing because it used Python code with multiple blank lines, expecting Qodana to detect it as a problem. However, the `qodana.starter` profile does not include blank line inspections.

Failing runs:
- https://github.com/JetBrains/qodana-action/actions/runs/25806655112/job/75811191122
- https://github.com/JetBrains/qodana-action/actions/runs/25210535634/job/73920040199

## Investigation
Tested different types of issues with `qodana-python-community:2026.1`:
- ❌ Multiple blank lines: 0 problems detected
- ❌ Undefined variable: 0 problems detected  
- ✅ Syntax error: 3 problems detected (High + Moderate severity)

## Solution
Updated test code to use Python syntax error which is reliably detected by the starter profile:
```python
def broken_function(
    print("syntax error")
```

## Testing
Verified locally that the test now passes:
```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Fixes https://youtrack.jetbrains.com/issue/QD-14658