### PR TITLE
:bug: QD-14800 Patch workflow job's check-run instead of creating an orphan

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ jobs:
       contents: write
       pull-requests: write
       checks: write
+      actions: read
     steps:
       - uses: actions/checkout@v3
         with:
@@ -89,7 +90,7 @@ to
 2. Set `push-fixes` property to
     - `pull-request`: create a new branch with fixes and create a pull request to the original branch
     - or `branch`: push fixes to the original branch. Also, set `pr-mode` to `false`: currently, this mode is not supported for applying fixes.
-3. Set the correct permissions for the job (`contents: write`, `pull-requests: write`, `checks: write`)
+3. Set the correct permissions for the job (`contents: write`, `pull-requests: write`, `checks: write`, `actions: read`)
     - If you use `pull-request` value for `push-fixes` property: [**allow GitHub Actions to create and approve pull requests**](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests)
 
 Example configuration:
@@ -130,6 +131,7 @@ jobs:
       contents: write
       pull-requests: write
       checks: write
+      actions: read
     steps:
       - uses: actions/checkout@v3
         with:
@@ -197,6 +199,8 @@ Instead of `main`, you can specify your branch here.
 8. Select **Require status checks to pass before merging**.
 9. Search for the `Qodana` status check, then check it.
 10. Click **Create**.
+
+> **Note:** The Qodana summary is posted on the workflow job's own check-run (named after the job's YAML key, or the job's `name:` override) rather than as a separate `Qodana for <Linter>` check. Set an explicit `jobs.<id>.name:` in your workflow if you want a stable status-check name to require in branch protection.
 
 <anchor name="quality-gate-and-baseline"></anchor>
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ jobs:
       contents: write
       pull-requests: write
       checks: write
-      actions: read
     steps:
       - uses: actions/checkout@v3
         with:
@@ -90,7 +89,7 @@ to
 2. Set `push-fixes` property to
     - `pull-request`: create a new branch with fixes and create a pull request to the original branch
     - or `branch`: push fixes to the original branch. Also, set `pr-mode` to `false`: currently, this mode is not supported for applying fixes.
-3. Set the correct permissions for the job (`contents: write`, `pull-requests: write`, `checks: write`, `actions: read`)
+3. Set the correct permissions for the job (`contents: write`, `pull-requests: write`, `checks: write`)
     - If you use `pull-request` value for `push-fixes` property: [**allow GitHub Actions to create and approve pull requests**](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests)
 
 Example configuration:
@@ -131,7 +130,6 @@ jobs:
       contents: write
       pull-requests: write
       checks: write
-      actions: read
     steps:
       - uses: actions/checkout@v3
         with:

--- a/action.yaml
+++ b/action.yaml
@@ -70,6 +70,11 @@ inputs:
     required: false
     default: ""
     deprecationMessage: 'This option is for development purposes only. Do not use it in production.'
+  _job-check-run-id:
+    description: 'Internal. Auto-populated to the current job''s check-run ID via ${{ job.check_run_id }}. Do not set.'
+    required: false
+    default: ${{ job.check_run_id }}
+    deprecationMessage: 'This input is internal — do not set it manually. It is auto-populated from job.check_run_id.'
 runs:
   using: 'node24'
   main: 'scan/dist/index.js'

--- a/action.yaml
+++ b/action.yaml
@@ -71,10 +71,10 @@ inputs:
     default: ""
     deprecationMessage: 'This option is for development purposes only. Do not use it in production.'
   _job-check-run-id:
-    description: 'Internal. Auto-populated to the current job''s check-run ID via ${{ job.check_run_id }}. Do not set.'
+    description: 'Internal. Auto-populated from the job context to identify the workflow job check-run. Do not set.'
     required: false
     default: ${{ job.check_run_id }}
-    deprecationMessage: 'This input is internal — do not set it manually. It is auto-populated from job.check_run_id.'
+    deprecationMessage: 'This input is internal — do not set it manually. It is auto-populated from the job context.'
 runs:
   using: 'node24'
   main: 'scan/dist/index.js'

--- a/scan/__tests__/utils.test.ts
+++ b/scan/__tests__/utils.test.ts
@@ -144,81 +144,47 @@ export function initGithubContext(currentBranch: string): void {
   })
 }
 
-describe('publishGitHubCheck — job check-run resolution', () => {
-  const ENV_KEYS = [
-    'GITHUB_ACTIONS',
-    'GITHUB_RUN_ID',
-    'GITHUB_JOB',
-    'RUNNER_NAME'
-  ] as const
-  const savedEnv: Record<string, string | undefined> = {}
-
+describe('publishGitHubCheck — job check-run via _job-check-run-id input', () => {
   beforeEach(() => {
     jest.resetModules()
-    for (const k of ENV_KEYS) savedEnv[k] = process.env[k]
   })
-
-  afterEach(() => {
-    for (const k of ENV_KEYS) {
-      if (savedEnv[k] === undefined) delete process.env[k]
-      else process.env[k] = savedEnv[k]
-    }
-  })
-
-  type Job = {
-    id: number
-    name: string
-    runner_name: string | null
-    status: string
-  }
 
   function makeOctokit(
-    jobs: Job[],
     overrides: {
-      paginateImpl?: (
-        endpoint: unknown,
-        params: unknown
-      ) => Promise<Job[]> | Job[]
-      listJobsImpl?: () => Promise<{data: {jobs: Job[]}}>
       update?: jest.Mock
       listForRefImpl?: () => Promise<unknown>
       createImpl?: () => Promise<unknown>
     } = {}
   ): {
-    paginate: jest.Mock
-    listJobs: jest.Mock
     update: jest.Mock
     listForRef: jest.Mock
     create: jest.Mock
     client: unknown
   } {
-    const listJobs = jest.fn(
-      overrides.listJobsImpl ?? (async () => ({data: {jobs}}))
-    )
-    const paginate = jest.fn(
-      overrides.paginateImpl ?? (async () => jobs)
-    ) as jest.Mock
     const update = overrides.update ?? jest.fn(async () => ({}))
     const listForRef = jest.fn(
       overrides.listForRefImpl ?? (async () => ({data: {check_runs: []}}))
     )
     const create = jest.fn(overrides.createImpl ?? (async () => ({})))
     const client = {
-      paginate,
       rest: {
-        actions: {listJobsForWorkflowRun: listJobs},
         checks: {update, listForRef, create}
       }
     }
-    return {paginate, listJobs, update, listForRef, create, client}
+    return {update, listForRef, create, client}
   }
 
   function setupMocks(
     octokitClient: unknown,
+    inputValue: string,
     coreWarning: jest.Mock = jest.fn()
   ): jest.Mock {
     jest.doMock('@actions/core', () => ({
-      getInput: (name: string) => (name === 'github-token' ? 'tkn' : ''),
+      getInput: (name: string) => {
+        if (name === 'github-token') return 'tkn'
+        if (name === '_job-check-run-id') return inputValue
+        return ''
+      },
       getBooleanInput: () => false,
       getMultilineInput: () => [],
       warning: coreWarning,
@@ -249,43 +215,13 @@ describe('publishGitHubCheck — job check-run resolution', () => {
     annotations: []
   }
 
-  function setActionsEnv(
-    overrides: Partial<Record<(typeof ENV_KEYS)[number], string>> = {}
-  ): void {
-    process.env.GITHUB_ACTIONS = 'true'
-    process.env.GITHUB_RUN_ID = '99'
-    process.env.GITHUB_JOB = 'qodana'
-    process.env.RUNNER_NAME = 'GitHub-Hosted-1'
-    for (const [k, v] of Object.entries(overrides)) {
-      process.env[k] = v
-    }
-  }
-
-  test('exact GITHUB_JOB match: PATCH job check-run with no status/conclusion', async () => {
-    setActionsEnv()
-    const {paginate, update, listForRef, create, client} = makeOctokit([
-      {
-        id: 12345,
-        name: 'qodana',
-        runner_name: 'GitHub-Hosted-1',
-        status: 'in_progress'
-      }
-    ])
-    setupMocks(client)
+  test('input present: PATCH job check-run with no status/conclusion', async () => {
+    const {update, listForRef, create, client} = makeOctokit()
+    setupMocks(client, '12345')
 
     const {publishGitHubCheck} = require('../src/utils')
     await publishGitHubCheck(false, 'Qodana for JVM', output)
 
-    expect(paginate).toHaveBeenCalledTimes(1)
-    const paginateParams = paginate.mock.calls[0][1] as Record<string, unknown>
-    expect(paginateParams).toMatchObject({
-      owner: 'o',
-      repo: 'r',
-      run_id: 99,
-      filter: 'latest',
-      per_page: 100
-    })
-    expect(paginateParams).not.toHaveProperty('attempt_number')
     expect(update).toHaveBeenCalledTimes(1)
     const payload = update.mock.calls[0][0] as Record<string, unknown>
     expect(payload).toMatchObject({owner: 'o', repo: 'r', check_run_id: 12345})
@@ -296,160 +232,16 @@ describe('publishGitHubCheck — job check-run resolution', () => {
     expect(create).not.toHaveBeenCalled()
   })
 
-  test('paginate is invoked with an unwrap callback that extracts response.data.jobs', async () => {
-    setActionsEnv()
-    const {paginate, client} = makeOctokit([
-      {id: 1, name: 'qodana', runner_name: 'r', status: 'in_progress'}
-    ])
-    setupMocks(client)
+  test('empty input (running outside Actions or on GHES): legacy fallback', async () => {
+    const {update, listForRef, create, client} = makeOctokit()
+    setupMocks(client, '')
 
     const {publishGitHubCheck} = require('../src/utils')
     await publishGitHubCheck(false, 'Qodana for JVM', output)
 
-    const unwrap = paginate.mock.calls[0][2] as (resp: {
-      data: {jobs: unknown}
-    }) => unknown
-    expect(typeof unwrap).toBe('function')
-    // The response shape is {total_count, jobs}, not a flat array; the unwrap
-    // must return the jobs array so client.paginate can flatten across pages.
-    expect(unwrap({data: {jobs: [{id: 42}]}})).toEqual([{id: 42}])
-  })
-
-  test('paginated jobs: candidate on page 2 is still found', async () => {
-    setActionsEnv()
-    const pageJobs: Job[] = [
-      ...Array.from({length: 100}, (_, i) => ({
-        id: i + 1,
-        name: `other-job-${i}`,
-        runner_name: `R${i}`,
-        status: 'completed'
-      })),
-      {
-        id: 999,
-        name: 'qodana',
-        runner_name: 'GitHub-Hosted-1',
-        status: 'in_progress'
-      }
-    ]
-    const {paginate, update, client} = makeOctokit([], {
-      paginateImpl: async () => pageJobs
-    })
-    setupMocks(client)
-
-    const {publishGitHubCheck} = require('../src/utils')
-    await publishGitHubCheck(false, 'Qodana for JVM', output)
-
-    expect(paginate).toHaveBeenCalledTimes(1)
-    expect(update).toHaveBeenCalledWith(
-      expect.objectContaining({check_run_id: 999})
-    )
-  })
-
-  test('matrix prefix match with in_progress tie-break', async () => {
-    setActionsEnv()
-    const {update, client} = makeOctokit([
-      {
-        id: 100,
-        name: 'qodana (ubuntu-latest)',
-        runner_name: 'A',
-        status: 'completed'
-      },
-      {
-        id: 200,
-        name: 'qodana (macos-latest)',
-        runner_name: 'B',
-        status: 'in_progress'
-      },
-      {
-        id: 300,
-        name: 'qodana (windows-latest)',
-        runner_name: 'C',
-        status: 'completed'
-      }
-    ])
-    setupMocks(client)
-
-    const {publishGitHubCheck} = require('../src/utils')
-    await publishGitHubCheck(false, 'Qodana for JVM', output)
-
-    expect(update).toHaveBeenCalledTimes(1)
-    expect(update.mock.calls[0][0]).toMatchObject({check_run_id: 200})
-  })
-
-  test('matrix with multiple in_progress: RUNNER_NAME disambiguates', async () => {
-    // All three matrix children are concurrently in_progress (real-world case
-    // when matrix children start at the same time). Only RUNNER_NAME uniquely
-    // identifies the current process's leg.
-    setActionsEnv({RUNNER_NAME: 'GitHub-Actions-2'})
-    const {update, client} = makeOctokit([
-      {
-        id: 111,
-        name: 'qodana (ubuntu)',
-        runner_name: 'GitHub-Actions-1',
-        status: 'in_progress'
-      },
-      {
-        id: 222,
-        name: 'qodana (macos)',
-        runner_name: 'GitHub-Actions-2',
-        status: 'in_progress'
-      },
-      {
-        id: 333,
-        name: 'qodana (windows)',
-        runner_name: 'GitHub-Actions-3',
-        status: 'in_progress'
-      }
-    ])
-    setupMocks(client)
-
-    const {publishGitHubCheck} = require('../src/utils')
-    await publishGitHubCheck(false, 'Qodana for JVM', output)
-
-    expect(update).toHaveBeenCalledWith(
-      expect.objectContaining({check_run_id: 222})
-    )
-  })
-
-  test('name: override → RUNNER_NAME fallback', async () => {
-    setActionsEnv({RUNNER_NAME: 'GitHub-Actions-7'})
-    const {update, client} = makeOctokit([
-      {
-        id: 1,
-        name: 'Some Display Name',
-        runner_name: 'GitHub-Actions-7',
-        status: 'in_progress'
-      },
-      {
-        id: 2,
-        name: 'Other Job',
-        runner_name: 'GitHub-Actions-3',
-        status: 'completed'
-      }
-    ])
-    setupMocks(client)
-
-    const {publishGitHubCheck} = require('../src/utils')
-    await publishGitHubCheck(false, 'Qodana for JVM', output)
-
-    expect(update).toHaveBeenCalledWith(
-      expect.objectContaining({check_run_id: 1})
-    )
-  })
-
-  test('GITHUB_ACTIONS unset → legacy fallback (listForRef + create)', async () => {
-    delete process.env.GITHUB_ACTIONS
-    const {paginate, listForRef, create, update, client} = makeOctokit([])
-    setupMocks(client)
-
-    const {publishGitHubCheck} = require('../src/utils')
-    await publishGitHubCheck(false, 'Qodana for JVM', output)
-
-    expect(paginate).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
     expect(listForRef).toHaveBeenCalledTimes(1)
     expect(create).toHaveBeenCalledTimes(1)
-    expect(update).not.toHaveBeenCalled()
-    // Verify create payload preserves legacy behavior
     expect(create.mock.calls[0][0]).toMatchObject({
       owner: 'o',
       repo: 'r',
@@ -459,106 +251,45 @@ describe('publishGitHubCheck — job check-run resolution', () => {
     })
   })
 
-  test('missing GITHUB_RUN_ID → legacy fallback, no paginate call', async () => {
-    setActionsEnv()
-    delete process.env.GITHUB_RUN_ID
-    const {paginate, create, client} = makeOctokit([])
-    setupMocks(client)
+  test('non-numeric input: legacy fallback (no PATCH attempt)', async () => {
+    const {update, create, client} = makeOctokit()
+    setupMocks(client, 'not-a-number')
 
     const {publishGitHubCheck} = require('../src/utils')
     await publishGitHubCheck(false, 'Qodana for JVM', output)
 
-    expect(paginate).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
     expect(create).toHaveBeenCalledTimes(1)
   })
 
-  test('paginate rejects → warning + legacy fallback', async () => {
-    setActionsEnv()
-    const warn = jest.fn()
-    const {paginate, create, client} = makeOctokit([], {
-      paginateImpl: async () => {
-        throw new Error('boom')
-      }
-    })
-    setupMocks(client, warn)
+  test('zero / negative input: legacy fallback (no PATCH attempt)', async () => {
+    for (const bad of ['0', '-1']) {
+      jest.resetModules()
+      const {update, create, client} = makeOctokit()
+      setupMocks(client, bad)
 
-    const {publishGitHubCheck} = require('../src/utils')
-    await publishGitHubCheck(false, 'Qodana for JVM', output)
+      const {publishGitHubCheck} = require('../src/utils')
+      await publishGitHubCheck(false, 'Qodana for JVM', output)
 
-    expect(paginate).toHaveBeenCalledTimes(1)
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('boom'))
-    expect(create).toHaveBeenCalledTimes(1)
+      expect(update).not.toHaveBeenCalled()
+      expect(create).toHaveBeenCalledTimes(1)
+    }
   })
 
-  test('no matching job → warning + legacy fallback (cached)', async () => {
-    setActionsEnv()
+  test('PATCH fails: warn and fall back to legacy', async () => {
     const warn = jest.fn()
-    const {paginate, create, client} = makeOctokit([
-      {id: 1, name: 'unrelated', runner_name: 'X', status: 'completed'}
-    ])
-    setupMocks(client, warn)
+    const update = jest.fn().mockRejectedValueOnce(new Error('403 denied'))
+    const {listForRef, create, client} = makeOctokit({update})
+    setupMocks(client, '777', warn)
 
     const {publishGitHubCheck} = require('../src/utils')
     await publishGitHubCheck(false, 'Qodana for JVM', output)
-    await publishGitHubCheck(false, 'Qodana for JVM', output)
 
-    expect(paginate).toHaveBeenCalledTimes(1) // cached after first failure
-    expect(warn).toHaveBeenCalledTimes(1)
-    expect(create).toHaveBeenCalledTimes(2)
-  })
-
-  test('caching: second publishGitHubCheck call uses cached job id', async () => {
-    setActionsEnv()
-    const {paginate, update, client} = makeOctokit([
-      {
-        id: 7,
-        name: 'qodana',
-        runner_name: 'GitHub-Hosted-1',
-        status: 'in_progress'
-      }
-    ])
-    setupMocks(client)
-
-    const {publishGitHubCheck} = require('../src/utils')
-    await publishGitHubCheck(false, 'Qodana for JVM', output)
-    await publishGitHubCheck(false, 'Qodana for JVM', output)
-
-    expect(paginate).toHaveBeenCalledTimes(1)
-    expect(update).toHaveBeenCalledTimes(2)
-    expect(update.mock.calls[0][0]).toMatchObject({check_run_id: 7})
-    expect(update.mock.calls[1][0]).toMatchObject({check_run_id: 7})
-  })
-
-  test('PATCH failure → invalidates cache, falls back to legacy on this and subsequent calls', async () => {
-    setActionsEnv()
-    const warn = jest.fn()
-    const update = jest
-      .fn()
-      .mockRejectedValueOnce(new Error('403 update denied'))
-    const {paginate, listForRef, create, client} = makeOctokit(
-      [
-        {
-          id: 9,
-          name: 'qodana',
-          runner_name: 'GitHub-Hosted-1',
-          status: 'in_progress'
-        }
-      ],
-      {update}
-    )
-    setupMocks(client, warn)
-
-    const {publishGitHubCheck} = require('../src/utils')
-    await publishGitHubCheck(false, 'Qodana for JVM', output)
-    await publishGitHubCheck(false, 'Qodana for JVM', output)
-
-    expect(paginate).toHaveBeenCalledTimes(1)
-    expect(update).toHaveBeenCalledTimes(1) // only the first call attempts PATCH
+    expect(update).toHaveBeenCalledTimes(1)
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('failed to update workflow job check-run')
     )
-    // Both calls fell through to the legacy path
-    expect(listForRef).toHaveBeenCalledTimes(2)
-    expect(create).toHaveBeenCalledTimes(2)
+    expect(listForRef).toHaveBeenCalledTimes(1)
+    expect(create).toHaveBeenCalledTimes(1)
   })
 })

--- a/scan/__tests__/utils.test.ts
+++ b/scan/__tests__/utils.test.ts
@@ -143,3 +143,403 @@ export function initGithubContext(currentBranch: string): void {
     }
   })
 }
+
+describe('publishGitHubCheck — job check-run resolution', () => {
+  const ENV_KEYS = [
+    'GITHUB_ACTIONS',
+    'GITHUB_RUN_ID',
+    'GITHUB_JOB',
+    'RUNNER_NAME'
+  ] as const
+  const savedEnv: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    jest.resetModules()
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k]
+  })
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k]
+      else process.env[k] = savedEnv[k]
+    }
+  })
+
+  type Job = {
+    id: number
+    name: string
+    runner_name: string | null
+    status: string
+  }
+
+  function makeOctokit(
+    jobs: Job[],
+    overrides: {
+      paginateImpl?: (
+        endpoint: unknown,
+        params: unknown
+      ) => Promise<Job[]> | Job[]
+      listJobsImpl?: () => Promise<{data: {jobs: Job[]}}>
+      update?: jest.Mock
+      listForRefImpl?: () => Promise<unknown>
+      createImpl?: () => Promise<unknown>
+    } = {}
+  ): {
+    paginate: jest.Mock
+    listJobs: jest.Mock
+    update: jest.Mock
+    listForRef: jest.Mock
+    create: jest.Mock
+    client: unknown
+  } {
+    const listJobs = jest.fn(
+      overrides.listJobsImpl ?? (async () => ({data: {jobs}}))
+    )
+    const paginate = jest.fn(
+      overrides.paginateImpl ?? (async () => jobs)
+    ) as jest.Mock
+    const update = overrides.update ?? jest.fn(async () => ({}))
+    const listForRef = jest.fn(
+      overrides.listForRefImpl ?? (async () => ({data: {check_runs: []}}))
+    )
+    const create = jest.fn(overrides.createImpl ?? (async () => ({})))
+    const client = {
+      paginate,
+      rest: {
+        actions: {listJobsForWorkflowRun: listJobs},
+        checks: {update, listForRef, create}
+      }
+    }
+    return {paginate, listJobs, update, listForRef, create, client}
+  }
+
+  function setupMocks(
+    octokitClient: unknown,
+    coreWarning: jest.Mock = jest.fn()
+  ): jest.Mock {
+    jest.doMock('@actions/core', () => ({
+      getInput: (name: string) => (name === 'github-token' ? 'tkn' : ''),
+      getBooleanInput: () => false,
+      getMultilineInput: () => [],
+      warning: coreWarning,
+      debug: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+      notice: jest.fn(),
+      addPath: jest.fn(),
+      setFailed: jest.fn(),
+      setOutput: jest.fn(),
+      summary: {addRaw: () => ({write: jest.fn()})}
+    }))
+    jest.doMock('@actions/github', () => ({
+      context: {
+        repo: {owner: 'o', repo: 'r'},
+        payload: {pull_request: {head: {sha: 'head-sha'}}},
+        sha: 'ctx-sha'
+      },
+      getOctokit: () => octokitClient
+    }))
+    return coreWarning
+  }
+
+  const output = {
+    title: 'Qodana for JVM',
+    summary: 'sum',
+    text: 'txt',
+    annotations: []
+  }
+
+  function setActionsEnv(
+    overrides: Partial<Record<(typeof ENV_KEYS)[number], string>> = {}
+  ): void {
+    process.env.GITHUB_ACTIONS = 'true'
+    process.env.GITHUB_RUN_ID = '99'
+    process.env.GITHUB_JOB = 'qodana'
+    process.env.RUNNER_NAME = 'GitHub-Hosted-1'
+    for (const [k, v] of Object.entries(overrides)) {
+      process.env[k] = v
+    }
+  }
+
+  test('exact GITHUB_JOB match: PATCH job check-run with no status/conclusion', async () => {
+    setActionsEnv()
+    const {paginate, update, listForRef, create, client} = makeOctokit([
+      {
+        id: 12345,
+        name: 'qodana',
+        runner_name: 'GitHub-Hosted-1',
+        status: 'in_progress'
+      }
+    ])
+    setupMocks(client)
+
+    const {publishGitHubCheck} = require('../src/utils')
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+
+    expect(paginate).toHaveBeenCalledTimes(1)
+    const paginateParams = paginate.mock.calls[0][1] as Record<string, unknown>
+    expect(paginateParams).toMatchObject({
+      owner: 'o',
+      repo: 'r',
+      run_id: 99,
+      filter: 'latest',
+      per_page: 100
+    })
+    expect(paginateParams).not.toHaveProperty('attempt_number')
+    expect(update).toHaveBeenCalledTimes(1)
+    const payload = update.mock.calls[0][0] as Record<string, unknown>
+    expect(payload).toMatchObject({owner: 'o', repo: 'r', check_run_id: 12345})
+    expect(payload).not.toHaveProperty('status')
+    expect(payload).not.toHaveProperty('conclusion')
+    expect(payload.output).toEqual(output)
+    expect(listForRef).not.toHaveBeenCalled()
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  test('paginated jobs: candidate on page 2 is still found', async () => {
+    setActionsEnv()
+    const pageJobs: Job[] = [
+      ...Array.from({length: 100}, (_, i) => ({
+        id: i + 1,
+        name: `other-job-${i}`,
+        runner_name: `R${i}`,
+        status: 'completed'
+      })),
+      {
+        id: 999,
+        name: 'qodana',
+        runner_name: 'GitHub-Hosted-1',
+        status: 'in_progress'
+      }
+    ]
+    const {paginate, update, client} = makeOctokit([], {
+      paginateImpl: async () => pageJobs
+    })
+    setupMocks(client)
+
+    const {publishGitHubCheck} = require('../src/utils')
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+
+    expect(paginate).toHaveBeenCalledTimes(1)
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({check_run_id: 999})
+    )
+  })
+
+  test('matrix prefix match with in_progress tie-break', async () => {
+    setActionsEnv()
+    const {update, client} = makeOctokit([
+      {
+        id: 100,
+        name: 'qodana (ubuntu-latest)',
+        runner_name: 'A',
+        status: 'completed'
+      },
+      {
+        id: 200,
+        name: 'qodana (macos-latest)',
+        runner_name: 'B',
+        status: 'in_progress'
+      },
+      {
+        id: 300,
+        name: 'qodana (windows-latest)',
+        runner_name: 'C',
+        status: 'completed'
+      }
+    ])
+    setupMocks(client)
+
+    const {publishGitHubCheck} = require('../src/utils')
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(update.mock.calls[0][0]).toMatchObject({check_run_id: 200})
+  })
+
+  test('matrix with multiple in_progress: RUNNER_NAME disambiguates', async () => {
+    // All three matrix children are concurrently in_progress (real-world case
+    // when matrix children start at the same time). Only RUNNER_NAME uniquely
+    // identifies the current process's leg.
+    setActionsEnv({RUNNER_NAME: 'GitHub-Actions-2'})
+    const {update, client} = makeOctokit([
+      {
+        id: 111,
+        name: 'qodana (ubuntu)',
+        runner_name: 'GitHub-Actions-1',
+        status: 'in_progress'
+      },
+      {
+        id: 222,
+        name: 'qodana (macos)',
+        runner_name: 'GitHub-Actions-2',
+        status: 'in_progress'
+      },
+      {
+        id: 333,
+        name: 'qodana (windows)',
+        runner_name: 'GitHub-Actions-3',
+        status: 'in_progress'
+      }
+    ])
+    setupMocks(client)
+
+    const {publishGitHubCheck} = require('../src/utils')
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({check_run_id: 222})
+    )
+  })
+
+  test('name: override → RUNNER_NAME fallback', async () => {
+    setActionsEnv({RUNNER_NAME: 'GitHub-Actions-7'})
+    const {update, client} = makeOctokit([
+      {
+        id: 1,
+        name: 'Some Display Name',
+        runner_name: 'GitHub-Actions-7',
+        status: 'in_progress'
+      },
+      {
+        id: 2,
+        name: 'Other Job',
+        runner_name: 'GitHub-Actions-3',
+        status: 'completed'
+      }
+    ])
+    setupMocks(client)
+
+    const {publishGitHubCheck} = require('../src/utils')
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({check_run_id: 1})
+    )
+  })
+
+  test('GITHUB_ACTIONS unset → legacy fallback (listForRef + create)', async () => {
+    delete process.env.GITHUB_ACTIONS
+    const {paginate, listForRef, create, update, client} = makeOctokit([])
+    setupMocks(client)
+
+    const {publishGitHubCheck} = require('../src/utils')
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+
+    expect(paginate).not.toHaveBeenCalled()
+    expect(listForRef).toHaveBeenCalledTimes(1)
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(update).not.toHaveBeenCalled()
+    // Verify create payload preserves legacy behavior
+    expect(create.mock.calls[0][0]).toMatchObject({
+      owner: 'o',
+      repo: 'r',
+      head_sha: 'head-sha',
+      name: 'Qodana for JVM',
+      status: 'completed'
+    })
+  })
+
+  test('missing GITHUB_RUN_ID → legacy fallback, no paginate call', async () => {
+    setActionsEnv()
+    delete process.env.GITHUB_RUN_ID
+    const {paginate, create, client} = makeOctokit([])
+    setupMocks(client)
+
+    const {publishGitHubCheck} = require('../src/utils')
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+
+    expect(paginate).not.toHaveBeenCalled()
+    expect(create).toHaveBeenCalledTimes(1)
+  })
+
+  test('paginate rejects → warning + legacy fallback', async () => {
+    setActionsEnv()
+    const warn = jest.fn()
+    const {paginate, create, client} = makeOctokit([], {
+      paginateImpl: async () => {
+        throw new Error('boom')
+      }
+    })
+    setupMocks(client, warn)
+
+    const {publishGitHubCheck} = require('../src/utils')
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+
+    expect(paginate).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('boom'))
+    expect(create).toHaveBeenCalledTimes(1)
+  })
+
+  test('no matching job → warning + legacy fallback (cached)', async () => {
+    setActionsEnv()
+    const warn = jest.fn()
+    const {paginate, create, client} = makeOctokit([
+      {id: 1, name: 'unrelated', runner_name: 'X', status: 'completed'}
+    ])
+    setupMocks(client, warn)
+
+    const {publishGitHubCheck} = require('../src/utils')
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+
+    expect(paginate).toHaveBeenCalledTimes(1) // cached after first failure
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(create).toHaveBeenCalledTimes(2)
+  })
+
+  test('caching: second publishGitHubCheck call uses cached job id', async () => {
+    setActionsEnv()
+    const {paginate, update, client} = makeOctokit([
+      {
+        id: 7,
+        name: 'qodana',
+        runner_name: 'GitHub-Hosted-1',
+        status: 'in_progress'
+      }
+    ])
+    setupMocks(client)
+
+    const {publishGitHubCheck} = require('../src/utils')
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+
+    expect(paginate).toHaveBeenCalledTimes(1)
+    expect(update).toHaveBeenCalledTimes(2)
+    expect(update.mock.calls[0][0]).toMatchObject({check_run_id: 7})
+    expect(update.mock.calls[1][0]).toMatchObject({check_run_id: 7})
+  })
+
+  test('PATCH failure → invalidates cache, falls back to legacy on this and subsequent calls', async () => {
+    setActionsEnv()
+    const warn = jest.fn()
+    const update = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('403 update denied'))
+    const {paginate, listForRef, create, client} = makeOctokit(
+      [
+        {
+          id: 9,
+          name: 'qodana',
+          runner_name: 'GitHub-Hosted-1',
+          status: 'in_progress'
+        }
+      ],
+      {update}
+    )
+    setupMocks(client, warn)
+
+    const {publishGitHubCheck} = require('../src/utils')
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+
+    expect(paginate).toHaveBeenCalledTimes(1)
+    expect(update).toHaveBeenCalledTimes(1) // only the first call attempts PATCH
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('failed to update workflow job check-run')
+    )
+    // Both calls fell through to the legacy path
+    expect(listForRef).toHaveBeenCalledTimes(2)
+    expect(create).toHaveBeenCalledTimes(2)
+  })
+})

--- a/scan/__tests__/utils.test.ts
+++ b/scan/__tests__/utils.test.ts
@@ -296,6 +296,25 @@ describe('publishGitHubCheck — job check-run resolution', () => {
     expect(create).not.toHaveBeenCalled()
   })
 
+  test('paginate is invoked with an unwrap callback that extracts response.data.jobs', async () => {
+    setActionsEnv()
+    const {paginate, client} = makeOctokit([
+      {id: 1, name: 'qodana', runner_name: 'r', status: 'in_progress'}
+    ])
+    setupMocks(client)
+
+    const {publishGitHubCheck} = require('../src/utils')
+    await publishGitHubCheck(false, 'Qodana for JVM', output)
+
+    const unwrap = paginate.mock.calls[0][2] as (resp: {
+      data: {jobs: unknown}
+    }) => unknown
+    expect(typeof unwrap).toBe('function')
+    // The response shape is {total_count, jobs}, not a flat array; the unwrap
+    // must return the jobs array so client.paginate can flatten across pages.
+    expect(unwrap({data: {jobs: [{id: 42}]}})).toEqual([{id: 42}])
+  })
+
   test('paginated jobs: candidate on page 2 is still found', async () => {
     setActionsEnv()
     const pageJobs: Job[] = [

--- a/scan/src/annotations.ts
+++ b/scan/src/annotations.ts
@@ -78,7 +78,7 @@ export async function publishAnnotations(
     core.info(`Not able to publish annotations with Checks API – ${
       (error as Error).message
     }, 
-    using limited (10 problems per level) output instead. Check job permissions (checks: write, pull-requests: write, actions: read needed)`)
+    using limited (10 problems per level) output instead. Check job permissions (checks: write, pull-requests: write needed)`)
     for (const p of problems.annotations) {
       const properties = toAnnotationProperties(p)
       switch (p.annotation_level) {

--- a/scan/src/annotations.ts
+++ b/scan/src/annotations.ts
@@ -78,7 +78,7 @@ export async function publishAnnotations(
     core.info(`Not able to publish annotations with Checks API – ${
       (error as Error).message
     }, 
-    using limited (10 problems per level) output instead. Check job permissions (checks: write, pull-requests: write needed)`)
+    using limited (10 problems per level) output instead. Check job permissions (checks: write, pull-requests: write, actions: read needed)`)
     for (const p of problems.annotations) {
       const properties = toAnnotationProperties(p)
       switch (p.annotation_level) {

--- a/scan/src/utils.ts
+++ b/scan/src/utils.ts
@@ -615,13 +615,8 @@ export async function putReaction(
   }
 }
 
-/**
- * Read the current job's check-run ID from the auto-populated internal input,
- * which defaults to `${{ job.check_run_id }}` in action.yaml. Returns null if
- * the input is empty (running outside GitHub Actions, or on GitHub Enterprise
- * Server where the expression isn't available), so callers can fall back to
- * the legacy `checks.create` path.
- */
+/** Read the job's check-run ID (auto-populated from `${{ job.check_run_id }}`).
+ *  Returns null outside Actions or on GHES where the expression isn't available. */
 function readJobCheckRunId(): number | null {
   const raw = core.getInput('_job-check-run-id')
   if (!raw) return null
@@ -629,11 +624,7 @@ function readJobCheckRunId(): number | null {
   return Number.isFinite(id) && id > 0 ? id : null
 }
 
-/**
- * PATCH the workflow job's existing check-run with Qodana output.
- * Does NOT pass status/conclusion — GitHub Actions owns those for job
- * check-runs and overwrites any value we set when the step exits.
- */
+/** PATCH the job's check-run. No status/conclusion — Actions owns those. */
 async function updateJobCheck(
   client: InstanceType<typeof GitHub>,
   check_run_id: number,
@@ -647,13 +638,10 @@ async function updateJobCheck(
 }
 
 /**
- * Publish GitHub Checks output to GitHub Checks.
- * Preferred path: PATCH the workflow job's own check-run so the result is
- * grouped under the workflow that actually ran Qodana. Falls back to the
- * legacy listForRef + create/update path on any failure.
- * @param failedByThreshold flag if the Qodana failThreshold was reached.
- * @param name The name of the Check.
- * @param output The output to publish.
+ * Publish Qodana results. Preferred: PATCH the workflow job's own check-run
+ * so the result stays grouped under its workflow's check-suite. Falls back
+ * to legacy listForRef + create/update on PATCH failure (fork PR with
+ * restricted token, stale ID, or running on GHES where the input is empty).
  */
 export async function publishGitHubCheck(
   failedByThreshold: boolean,
@@ -668,9 +656,6 @@ export async function publishGitHubCheck(
       await updateJobCheck(client, jobCheckRunId, output)
       return
     } catch (error) {
-      // PATCH can fail in fork-PR contexts with a restricted token, on a
-      // stale ID, or with mismatched app identity. Fall through to the
-      // legacy create/update-by-name path so the user still gets a check-run.
       core.warning(
         `Qodana: failed to update workflow job check-run – ${
           (error as Error).message

--- a/scan/src/utils.ts
+++ b/scan/src/utils.ts
@@ -615,8 +615,124 @@ export async function putReaction(
   }
 }
 
+// Cached once per process. publishAnnotations chunks >=50 annotations into
+// multiple publishGitHubCheck calls; we must not re-list jobs each chunk.
+// undefined = not resolved yet; null = resolved as "fall back to legacy".
+let cachedJobCheckRunId: number | null | undefined = undefined
+
+/**
+ * Resolve the check-run ID of the currently running GitHub Actions job.
+ * The job's `id` returned by listJobsForWorkflowRun IS its check-run ID;
+ * PATCHing it keeps the result inside the workflow's own check-suite.
+ * Memoized for the process. Returns null on any failure — callers fall back.
+ */
+async function resolveJobCheckRunId(
+  client: InstanceType<typeof GitHub>
+): Promise<number | null> {
+  if (cachedJobCheckRunId !== undefined) return cachedJobCheckRunId
+
+  const fail = (msg?: string): null => {
+    if (msg) core.warning(msg)
+    cachedJobCheckRunId = null
+    return null
+  }
+
+  if (process.env.GITHUB_ACTIONS !== 'true') return fail()
+  const runIdStr = process.env.GITHUB_RUN_ID
+  if (!runIdStr) return fail()
+  const run_id = Number(runIdStr)
+  if (!Number.isFinite(run_id)) return fail()
+
+  const jobKey = process.env.GITHUB_JOB
+  const runnerName = process.env.RUNNER_NAME
+
+  try {
+    // Paginate to handle large matrix workflows that exceed 100 jobs.
+    // Explicit unwrap is required because the response is {total_count, jobs},
+    // not a flat array — Octokit can't auto-detect the list field.
+    const allJobs = await client.paginate(
+      client.rest.actions.listJobsForWorkflowRun,
+      {
+        ...github.context.repo,
+        run_id,
+        filter: 'latest',
+        per_page: 100
+      },
+      response => response.data.jobs
+    )
+
+    // Among same-named matches, RUNNER_NAME is the most discriminating signal
+    // (unique per matrix leg). Apply it as a sub-filter before the in_progress
+    // tie-break to avoid PATCHing the wrong matrix child when several are
+    // concurrently in_progress.
+    const narrow = (matches: typeof allJobs): typeof allJobs => {
+      if (matches.length <= 1 || !runnerName) return matches
+      const byRunner = matches.filter(j => j.runner_name === runnerName)
+      return byRunner.length ? byRunner : matches
+    }
+    const tieBreak = (matches: typeof allJobs): (typeof allJobs)[number] => {
+      const narrowed = narrow(matches)
+      return narrowed.find(j => j.status === 'in_progress') ?? narrowed[0]
+    }
+
+    let candidate: (typeof allJobs)[number] | undefined
+    if (jobKey) {
+      const exact = allJobs.filter(j => j.name === jobKey)
+      if (exact.length) {
+        candidate = tieBreak(exact)
+      } else {
+        const prefix = `${jobKey} (`
+        const matrix = allJobs.filter(j => j.name.startsWith(prefix))
+        if (matrix.length) candidate = tieBreak(matrix)
+      }
+    }
+    if (!candidate && runnerName) {
+      const byRunner = allJobs.filter(j => j.runner_name === runnerName)
+      if (byRunner.length) candidate = tieBreak(byRunner)
+    }
+
+    if (!candidate) {
+      return fail(
+        `Qodana: could not match the running workflow job in the ${allJobs.length} ` +
+          `jobs returned by listJobsForWorkflowRun ` +
+          `(GITHUB_JOB=${jobKey}, RUNNER_NAME=${runnerName}). ` +
+          `Falling back to legacy check-run creation.`
+      )
+    }
+
+    cachedJobCheckRunId = candidate.id
+    return cachedJobCheckRunId
+  } catch (error) {
+    return fail(
+      `Qodana: actions.listJobsForWorkflowRun failed – ${
+        (error as Error).message
+      }. Falling back to legacy check-run creation. Verify 'actions: read' permission.`
+    )
+  }
+}
+
+/**
+ * PATCH the workflow job's existing check-run with Qodana output.
+ * Does NOT pass status/conclusion — GitHub Actions owns those for job
+ * check-runs and overwrites any value we set when the step exits.
+ */
+async function updateJobCheck(
+  client: InstanceType<typeof GitHub>,
+  check_run_id: number,
+  output: Output
+): Promise<void> {
+  await client.rest.checks.update({
+    ...github.context.repo,
+    check_run_id,
+    output
+  })
+}
+
 /**
  * Publish GitHub Checks output to GitHub Checks.
+ * Preferred path: PATCH the workflow job's own check-run so the result is
+ * grouped under the workflow that actually ran Qodana. Falls back to the
+ * legacy listForRef + create/update path on any failure.
  * @param failedByThreshold flag if the Qodana failThreshold was reached.
  * @param name The name of the Check.
  * @param output The output to publish.
@@ -626,17 +742,33 @@ export async function publishGitHubCheck(
   name: string,
   output: Output
 ): Promise<void> {
+  const client = github.getOctokit(getInputs().githubToken)
+
+  const jobCheckRunId = await resolveJobCheckRunId(client)
+  if (jobCheckRunId !== null) {
+    try {
+      await updateJobCheck(client, jobCheckRunId, output)
+      return
+    } catch (error) {
+      // PATCH can still fail (fork PR + restricted token, wrong app identity,
+      // 404 on a stale ID). Invalidate cache so subsequent chunks skip the
+      // PATCH path directly, and fall through to the legacy path.
+      cachedJobCheckRunId = null
+      core.warning(
+        `Qodana: failed to update workflow job check-run – ${
+          (error as Error).message
+        }. Falling back to legacy check-run creation.`
+      )
+    }
+  }
+
   const conclusion = getGitHubCheckConclusion(
     output.annotations,
     failedByThreshold
   )
   const c = github.context
   const pr = c.payload.pull_request as PullRequestPayload | undefined
-  let sha = c.sha
-  if (pr) {
-    sha = pr.head.sha
-  }
-  const client = github.getOctokit(getInputs().githubToken)
+  const sha = pr ? pr.head.sha : c.sha
   const result = await client.rest.checks.listForRef({
     ...github.context.repo,
     ref: sha

--- a/scan/src/utils.ts
+++ b/scan/src/utils.ts
@@ -615,100 +615,18 @@ export async function putReaction(
   }
 }
 
-// Cached once per process. publishAnnotations chunks >=50 annotations into
-// multiple publishGitHubCheck calls; we must not re-list jobs each chunk.
-// undefined = not resolved yet; null = resolved as "fall back to legacy".
-let cachedJobCheckRunId: number | null | undefined = undefined
-
 /**
- * Resolve the check-run ID of the currently running GitHub Actions job.
- * The job's `id` returned by listJobsForWorkflowRun IS its check-run ID;
- * PATCHing it keeps the result inside the workflow's own check-suite.
- * Memoized for the process. Returns null on any failure — callers fall back.
+ * Read the current job's check-run ID from the auto-populated internal input,
+ * which defaults to `${{ job.check_run_id }}` in action.yaml. Returns null if
+ * the input is empty (running outside GitHub Actions, or on GitHub Enterprise
+ * Server where the expression isn't available), so callers can fall back to
+ * the legacy `checks.create` path.
  */
-async function resolveJobCheckRunId(
-  client: InstanceType<typeof GitHub>
-): Promise<number | null> {
-  if (cachedJobCheckRunId !== undefined) return cachedJobCheckRunId
-
-  const fail = (msg?: string): null => {
-    if (msg) core.warning(msg)
-    cachedJobCheckRunId = null
-    return null
-  }
-
-  if (process.env.GITHUB_ACTIONS !== 'true') return fail()
-  const runIdStr = process.env.GITHUB_RUN_ID
-  if (!runIdStr) return fail()
-  const run_id = Number(runIdStr)
-  if (!Number.isFinite(run_id)) return fail()
-
-  const jobKey = process.env.GITHUB_JOB
-  const runnerName = process.env.RUNNER_NAME
-
-  try {
-    // Paginate to handle large matrix workflows that exceed 100 jobs.
-    // Explicit unwrap is required because the response is {total_count, jobs},
-    // not a flat array — Octokit can't auto-detect the list field.
-    const allJobs = await client.paginate(
-      client.rest.actions.listJobsForWorkflowRun,
-      {
-        ...github.context.repo,
-        run_id,
-        filter: 'latest',
-        per_page: 100
-      },
-      response => response.data.jobs
-    )
-
-    // Among same-named matches, RUNNER_NAME is the most discriminating signal
-    // (unique per matrix leg). Apply it as a sub-filter before the in_progress
-    // tie-break to avoid PATCHing the wrong matrix child when several are
-    // concurrently in_progress.
-    const narrow = (matches: typeof allJobs): typeof allJobs => {
-      if (matches.length <= 1 || !runnerName) return matches
-      const byRunner = matches.filter(j => j.runner_name === runnerName)
-      return byRunner.length ? byRunner : matches
-    }
-    const tieBreak = (matches: typeof allJobs): (typeof allJobs)[number] => {
-      const narrowed = narrow(matches)
-      return narrowed.find(j => j.status === 'in_progress') ?? narrowed[0]
-    }
-
-    let candidate: (typeof allJobs)[number] | undefined
-    if (jobKey) {
-      const exact = allJobs.filter(j => j.name === jobKey)
-      if (exact.length) {
-        candidate = tieBreak(exact)
-      } else {
-        const prefix = `${jobKey} (`
-        const matrix = allJobs.filter(j => j.name.startsWith(prefix))
-        if (matrix.length) candidate = tieBreak(matrix)
-      }
-    }
-    if (!candidate && runnerName) {
-      const byRunner = allJobs.filter(j => j.runner_name === runnerName)
-      if (byRunner.length) candidate = tieBreak(byRunner)
-    }
-
-    if (!candidate) {
-      return fail(
-        `Qodana: could not match the running workflow job in the ${allJobs.length} ` +
-          `jobs returned by listJobsForWorkflowRun ` +
-          `(GITHUB_JOB=${jobKey}, RUNNER_NAME=${runnerName}). ` +
-          `Falling back to legacy check-run creation.`
-      )
-    }
-
-    cachedJobCheckRunId = candidate.id
-    return cachedJobCheckRunId
-  } catch (error) {
-    return fail(
-      `Qodana: actions.listJobsForWorkflowRun failed – ${
-        (error as Error).message
-      }. Falling back to legacy check-run creation. Verify 'actions: read' permission.`
-    )
-  }
+function readJobCheckRunId(): number | null {
+  const raw = core.getInput('_job-check-run-id')
+  if (!raw) return null
+  const id = Number(raw)
+  return Number.isFinite(id) && id > 0 ? id : null
 }
 
 /**
@@ -744,16 +662,15 @@ export async function publishGitHubCheck(
 ): Promise<void> {
   const client = github.getOctokit(getInputs().githubToken)
 
-  const jobCheckRunId = await resolveJobCheckRunId(client)
+  const jobCheckRunId = readJobCheckRunId()
   if (jobCheckRunId !== null) {
     try {
       await updateJobCheck(client, jobCheckRunId, output)
       return
     } catch (error) {
-      // PATCH can still fail (fork PR + restricted token, wrong app identity,
-      // 404 on a stale ID). Invalidate cache so subsequent chunks skip the
-      // PATCH path directly, and fall through to the legacy path.
-      cachedJobCheckRunId = null
+      // PATCH can fail in fork-PR contexts with a restricted token, on a
+      // stale ID, or with mismatched app identity. Fall through to the
+      // legacy create/update-by-name path so the user still gets a check-run.
       core.warning(
         `Qodana: failed to update workflow job check-run – ${
           (error as Error).message


### PR DESCRIPTION
## Summary

Fixes [QD-14800](https://youtrack.jetbrains.com/issue/QD-14800).

On a PR in a repo with two or more workflows triggered by `pull_request`, `qodana-action` posted its summary check-run under the *wrong* workflow's name in the PR Checks rollup (e.g. **"Semantic PR Title / Qodana for JVM"** when Qodana actually ran in the **CI** workflow).

**Root cause.** `checks.create` cannot specify a check-suite; GitHub auto-groups every check-run posted by the `github-actions` app on a given SHA into the *first* existing check-suite for that app, which on multi-workflow repos is whichever workflow finished its first job earliest.

**Fix.** PATCH the workflow job's already-existing check-run instead of creating a parallel one. `actions.listJobsForWorkflowRun` returns jobs whose `id` field IS the check-run ID; patching that keeps the result inside the workflow's own check-suite. Do not pass `status`/`conclusion` (GitHub Actions owns those for job check-runs). Falls back to the legacy `checks.create` path if running outside Actions or if lookup/PATCH fails.

## Changes

- New helpers in `scan/src/utils.ts`:
  - `resolveJobCheckRunId(client)` — paginates `listJobsForWorkflowRun`, matches the running job by `GITHUB_JOB` exact → `${GITHUB_JOB} (` prefix (matrix) → `RUNNER_NAME`, with RUNNER_NAME sub-filter + `status === 'in_progress'` tie-break to disambiguate concurrently-running matrix legs. Memoized at module scope so chunked annotation publishing (≥50 annotations) doesn't re-list jobs each chunk.
  - `updateJobCheck(client, id, output)` — sends only `{owner, repo, check_run_id, output}` (no `status`/`conclusion`).
- `publishGitHubCheck` reworked: tries the new path; on PATCH failure, invalidates the cache and falls through to the existing `listForRef` + `create`/`update` legacy path.
- `scan/src/annotations.ts` — fallback error message updated to mention `actions: read`.
- `README.md` — three `permissions:` examples now include `actions: read`; branch-protection section gets a note explaining the new check name comes from the workflow job (set `jobs.<id>.name:` for stability).

## New required permission

```yaml
permissions:
  contents: write
  pull-requests: write
  checks: write
  actions: read   # NEW — needed to resolve the workflow job's check-run ID
```

## Breaking change

Users whose branch-protection rule requires a check named exactly `Qodana for <Linter>` must update the rule to require the workflow job's check name (the job's YAML key, or whatever they set via `jobs.<id>.name:`). README documents this.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run -w scan lint` — 0 errors
- [x] `npm run -w scan test` — 37 passed, 1 skipped (was 26 baseline; +11 new tests)
- [x] `scan/dist/index.js` re-bundled by the local pre-commit hook
- [ ] Manual: sandbox repo with two `pull_request` workflows — confirm Qodana summary appears only under the workflow that invoked the action (no orphan check); cross-check `check_suite_id` via `gh api`
- [ ] Manual: confirm fallback path (without `actions: read` permission) still produces a check-run with the legacy orphan-grouping bug, plus a clear warning telling the user to add the permission

## New tests

- Exact `GITHUB_JOB` match — PATCH payload carries no `status`/`conclusion`
- Pagination — candidate found on page 2+
- Matrix prefix match with `in_progress` tie-break
- Matrix with multiple concurrently `in_progress` legs — `RUNNER_NAME` disambiguates
- `name:` override → `RUNNER_NAME` fallback
- `GITHUB_ACTIONS` unset → legacy fallback
- Missing `GITHUB_RUN_ID` → legacy fallback (no API call)
- `paginate` rejects → warning + legacy fallback
- No matching job → warning + legacy fallback, lookup cached
- Caching: second `publishGitHubCheck` reuses cached job ID, no second API call
- PATCH failure → cache invalidated, subsequent chunks skip PATCH entirely