### PR TITLE
:bug: QD-15013 Fix azure-dev-release workflow failure due to missing husky

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -413,7 +413,7 @@ jobs:
           cache: npm
       - name: Install dependencies
         if: steps.filter.outputs.azure-dev == 'true'
-        run: cd vsts && npm install && cd QodanaScan && npm install && npm i -g tfx-cli
+        run: npm ci && cd vsts && npm install && cd QodanaScan && npm install && npm i -g tfx-cli
       - name: Package and publish
         id: publisher-run
         if: steps.filter.outputs.azure-dev == 'true'


### PR DESCRIPTION
## Problem

The `azure-dev-release` job is failing with `sh: 1: husky: not found` error when executing `npm install` in the `vsts` subdirectory.

## Root Cause

After commit `cfac2b9` (QD-14680), husky was added to the root `package.json` with a `prepare` script. When `npm install` runs in the `vsts` subdirectory, npm attempts to execute the `prepare` script from the root package.json, but husky is not installed because root dependencies were never installed.

## Solution

This PR adds `npm ci` before the vsts installation to ensure root dependencies (including husky) are properly installed.

## Changes

- Updated `.github/workflows/node.yml` line 416: added `npm ci &&` before `cd vsts && npm install`

## Testing

This fix will be validated by the azure-dev-release workflow running successfully on this PR.

Fixes: https://youtrack.jetbrains.com/issue/QD-15013
Related to: cfac2b9 (QD-14680)