### PR TITLE
:bug: QD-15013 Fix azure release workflow husky error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           node-version-file: .node-version
           cache: npm
       - name: Install dependencies
-        run: cd vsts && npm install && cd QodanaScan && npm install && npm i -g tfx-cli
+        run: npm ci && cd vsts && npm install && cd QodanaScan && npm install && npm i -g tfx-cli
       - name: Package and publish
         run: |
           cd vsts && npm run azure


### PR DESCRIPTION
Fixes the same husky error in the release workflow's azure job by ensuring root dependencies are installed first with `npm ci` before running workspace-specific installations.